### PR TITLE
Update gospl/tools/inputparser.py

### DIFF
--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -3,7 +3,7 @@ import sys
 import petsc4py
 import numpy as np
 import pandas as pd
-import ruamel.yaml as YAML
+from ruamel.yaml import YAML
 
 from operator import itemgetter
 from scipy.interpolate import interp1d
@@ -41,7 +41,7 @@ class ReadYaml(object):
 
         # Open YAML file
         with open(filename, "r") as finput:
-            yaml = YAML()
+            typ="unsafe", pure=True
             self.input = yaml.load(finput)
 
         if MPIrank == 0 and "name" in self.input.keys() and self.verbose:

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -41,7 +41,7 @@ class ReadYaml(object):
 
         # Open YAML file
         with open(filename, "r") as finput:
-            yaml = YAML(typ="unsafe", pure=True)
+            yaml = YAML()
             self.input = yaml.load(finput)
 
         if MPIrank == 0 and "name" in self.input.keys() and self.verbose:


### PR DESCRIPTION
The import statement ` import ruamel.yaml as YAML` in gospl/tools/inputparser.py causes TypeError: Module not callable. Using `from ruamel.yaml import YAML` resolves the issue.