### PR TITLE
Dual-lithology sediment: co-transport increment (Phases 0-2, 4-5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,11 +165,12 @@ Thickness conversion (in case of future refactors):
 One quirk worth knowing: **`sedplex._getSedFlux` (sedplex.py:63) negates `self.Eb` before the upstream-integration solve**, because that solve needs an erosion-positive source for `vSed` (m³/yr) to accumulate as positive downstream flux. The `stratNb > 0` branch uses `self.thCoarse` which is already erosion-positive (from `stratplex.erodeStrat`), so no negation there.
 
 ## The `_extra*` methods are mandatory continuations
-NOT optional parsers. Each sets attributes required by other modules. Never delete or rename without following the full call chain in `inputparser._readDomain/_readTime/_readHillslope/_readFlex/_readOrography/_readIce`.
+NOT optional parsers. Each sets attributes required by other modules. Never delete or rename without following the full call chain in `inputparser._readDomain/_readTime/_readHillslope/_readCompaction/_readFlex/_readOrography/_readIce`.
 
 - `_extraDomain` (inputparser.py:189) → `seaDepo`, `overlap`, `dataFile`, `nodep`, `strataFile`; calls `_extraDomain2`.
 - `_extraDomain2` (:229) → `advscheme`, `radius`, `gravity`.
 - `_extraHillslope` (:475) → `nlK`, `clinSlp`, `tsStep`, `Gmar`, `offshore`, `nl_pit_volume/depth/K/inlet_bias`.
+- `_extraStrata` (called from `_readCompaction`) → `stratLith` (dual-lithology master opt-in), `phi0c/z0c` (coarse porosity curve, defaults to compaction `phi0s/z0s`), `phi0f/z0f` (fine), `bedrock_coarse_frac`, `fine_efficiency`, `pit_inlet_bias_coarse/fine`, `Dc/Df`. All inert while `stratLith` is False; forced False if `stratNb == 0`. See `docs/DESIGN_DUAL_LITHOLOGY.md`.
 - `_extraFlex` (:1430) → `nu`, `flex_res_deg`, `flex_bcN/S/E/W`.
 - `_extraOrography` (:1517) → `oro_cw`, `oro_conv_time`, `oro_fall_time`, `oro_precip_*`, `rainfall_frequency`.
 - `_extraIce` (:1621) → `iceT`, `elaH`, `iceH` interpolators.

--- a/docs/DESIGN_DUAL_LITHOLOGY.md
+++ b/docs/DESIGN_DUAL_LITHOLOGY.md
@@ -1,0 +1,273 @@
+# DESIGN: Dual-lithology (coarse/fine) sediment option
+
+Status: **design / not yet implemented**. Target branch: `dev`.
+Last updated: 2026-06-12.
+
+This document is the implementation plan for adding an **opt-in dual-lithology**
+(coarse + fine) sediment capability to goSPL, active only when stratigraphy is
+turned on. When the option is **off (default), behaviour is bitwise-identical to
+the current single-fraction code** — every dual-lithology path is gated behind
+the flag.
+
+Read this alongside `AGENTS.md` (invariants), `docs/HOW_TO_ADD_FORCING.md`, and
+`docs/HOW_TO_ADD_OUTPUT.md`. It supersedes the "single value per layer" caveats
+in `docs/tech_guide/strat.rst` once shipped.
+
+---
+
+## 1. Scope & decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Number of lithologies | **Two**: coarse (sand) + fine (silt/clay) |
+| Composition source | **Per stratigraphic layer** — each layer carries its own coarse/fine split; eroded material inherits the composition of the layer(s) it came from |
+| Transport | **Separate** — fines travel farther (distal basin / depocenter); coarse stays proximal |
+| Lake/depression behaviour | Coarse builds **inlet deltas**, fines settle in the **depocenter**; fine-enriched overspill may bypass downstream while coarse is trapped |
+| Fortran kernel | Reuse existing **`stratathreesed`** (`fortran/functions.F90:1905`, bound in `functions.pyf:195`) with the weathered slot zeroed; dedicated 2-sed kernel is a later optimization |
+
+The dormant `stratathreesed` 3-fraction kernel already exists but is never called
+(today only `strataonesed` is, `stratplex.py:13,363`). This design wires up the
+2-fraction subset of it.
+
+---
+
+## 2. State variables
+
+Keep `self.stratH` = **total** layer thickness (so all existing compaction /
+elevation sums in `getCompaction`/`_depthPorosity` keep working) and add parallel
+fraction arrays, all shape `(lpoints, stratNb)`:
+
+| New array | Holds | Mirror of |
+|---|---|---|
+| `self.stratHf` | fine-fraction layer thickness (coarse = `stratH − stratHf`) | `stratH` |
+| `self.phiF` | fine porosity per layer (`phiS` is now coarse porosity) | `phiS` |
+
+Erosion-rate outputs become a pair: `self.thCoarse` **and** `self.thFine`
+(both m/yr, solid, uncompacted-equiv). Flag: `self.stratLith` (bool, default
+`False`).
+
+npstrata input gains optional `strataHf` + `phiF`; absent → all-coarse, so old
+input files still load unchanged.
+
+---
+
+## 3. YAML opt-in
+
+```yaml
+strata:
+  dual: True                          # default False -> current single-fraction path
+  coarse: {phi0: 0.49, z0: 3700.}     # coarse porosity-depth (today's phi0s/z0s = coarse)
+  fine:   {phi0: 0.63, z0: 1960.}     # fines: higher surface porosity, shallower decay
+  bedrock_coarse_frac: 0.5            # composition of the layer-0 bedrock sentinel
+  # transport / deposition contrast (the "fines travel farther" knobs):
+  fine_efficiency: <factor>           # marine: per-fraction Gmar (fine deposits less readily)
+  pitInletBias: {coarse: 0.5, fine: 0.0}   # lacustrine: coarse delta vs fine depocenter
+  Dc: <coeff>                         # subaerial + subaqueous diffusivity, coarse
+  Df: <coeff>                         # ... fine (Df > Dc)
+```
+
+Parsed by a new `_extraStrata` method in `tools/inputparser.py`, following the
+**mandatory `_extra*` continuation convention** (add it to the `_extra*` table in
+`AGENTS.md`). Sets `self.stratLith`, the two porosity curves, `fine_efficiency`,
+per-fraction inlet bias, and `Dc`/`Df`. All keys default such that `dual: False`
+reproduces current behaviour.
+
+---
+
+## 4. The two shared hooks (the core simplification)
+
+Lithology enters the physics through **one new helper plus the existing erode/
+depose path** — *not* through per-flavour math:
+
+- **`_surfaceComposition()`** — new helper in `stratplex.py`, modeled exactly on
+  the existing `_surfaceK()` (`stratplex.py:117`). Returns the exposed surface
+  layer's `(fc, ff)` per node. Returns all-coarse when `stratLith` is off or the
+  column is empty.
+
+This single helper feeds **all three** consumers:
+1. **Erodibility blend** — effective `K = fc·K_coarse + ff·K_fine`, inherited by
+   all three SPL flavours because they already scale `self.K` through
+   `_surfaceK`.
+2. **Eroded-mass split** — `erodeStrat` splits the eroded solid by the consumed
+   layers' composition (Section 6).
+3. **Diffusivity blend** — hillslope `D_eff = fc·Dc + ff·Df` (Section 7).
+
+---
+
+## 5. Erosion across the SPL flavours
+
+The SPL solvers produce a **total** erosion thickness rate (`Eb`, m/yr); they do
+**not** compute the coarse/fine split themselves. Lithology enters only via the
+two shared hooks above.
+
+| Flavour | Change for dual lithology |
+|---|---|
+| **SPL, detachment-limited** (`fDepa==0`, `SPL._getEroDepRate`) | None in the solve. K-blend + `erodeStrat` split. Deposition entirely in `sedplex` (Phase 3). Trivial. |
+| **nlSPL, detachment-limited** (`nlSPL._solveNL`) | Same — the nonlinear `n` acts on total stream power. Trivial. |
+| **SPL/nlSPL transport-limited** (`SPL._coupledEDSystem` `fDepa!=0`; `nlSPL._solveNL_ed`) | The one complication — deposition is baked into the erosion solve via a single `G`. **Resolution (A, default):** run SPL erosion-only in dual mode and defer per-fraction deposition (`Gc`/`Gf`) to the `sedplex` routing of Phase 3. **(B, opt-in later):** run the coupled solve twice with `Gc` then `Gf` (doubles the AD-HOC fieldsplit / cached `_snes_ed` cost). |
+| **soilSPL** (`soilSPL._solveSoil`) | Most lithology-intrinsic: the soil layer carries its own composition, and soil production weathers bedrock into **fine-enriched regolith** (`prodSoil`). Soil erosion splits by soil composition, exposed-bedrock erosion by `bedrock_coarse_frac`. |
+
+---
+
+## 6. Conservation: what happens when transport demand exceeds the top layer (CRITICAL)
+
+`D_eff` (and `K`) set the **magnitude** of total transport, never the
+**composition** of what is removed. Composition is always reconciled against the
+strata record by `erodeStrat`, integrating **layer by layer downward** (the
+existing `cumThick` consume loop, `stratplex.py:195-219`):
+
+1. The solve yields a **total** erosion depth at each node.
+2. `erodeStrat` consumes downward: takes all the fine in the top layer, then the
+   remaining demanded volume from the next layer at *that* layer's composition,
+   and so on. **A fraction can never be over-drawn** — each layer caps its own
+   contribution.
+3. The **bedrock sentinel** (`BEDROCK_SENTINEL`, `stratplex.py:99`, composition
+   `bedrock_coarse_frac`) is the ultimate backstop, so total volume is always
+   realizable — never a true "ran out," just erosion into bedrock.
+4. Deposited composition ≡ eroded composition → **per-fraction mass conserved
+   exactly**; no negative fractions.
+
+**Residual = a one-timestep explicit lag**, not a conservation error: `D_eff`
+used the *surface* composition while the removed mass is *layer-integrated*. It is
+bounded (diffusion is CFL/`tsStep`-limited), self-corrects next step (surface
+composition then reflects the freshly-exposed layer), and composition is frozen
+during the implicit elevation solve (operator-split; avoids a doubly-nonlinear
+SNES/TS). A guard + a "diffuse-through-a-compositional-boundary" regression test
+will flag if the lag ever matters; `D_eff` substepping is the escape hatch, not
+built speculatively.
+
+Mirror the existing negative-thickness clamp (`stratplex.py:226-228`) for
+`stratHf`/`phiF`.
+
+---
+
+## 7. Diffusion (hillslope + subaqueous)
+
+Today hillslope is **single-rate** for both grain sizes (`hillslope.py:64`).
+Add per-class `Dc`/`Df` and evaluate via **composition-weighted effective
+diffusivity in a single solve**:
+
+- `D_eff = fc·Dc + ff·Df` from `_surfaceComposition()`; the diffused flux carries
+  the **donor cell's composition** into `erodeStrat`/`deposeStrat`.
+- **Drop-in** to the existing solvers — the FV scheme already supports node-
+  varying diffusivity (the nonlinear hillslope varies D by slope via
+  `Dlimit`/`dexp`); composition is just a multiplicative factor. **No new cached
+  solver** (so no `destroy_DMPlex` churn) and **no two-field nonlinear coupling**.
+- A genuine two-field separate-D solve is more accurate but much heavier; offer
+  as a future opt-in only.
+
+**Subaqueous diffusion is where the D-contrast does the real work.** The marine +
+lake diffusion path (cached `_ts_marine`, `_diffuseImplicit` in `hillslope.py`)
+with `Df > Dc` is *the mechanism* by which fines spread to the depocenter while
+coarse stays proximal — i.e. it implements "fines travel farther" consistently
+with the lacustrine inlet-bias and marine `Gmar`:
+
+| Domain | "Fines travel farther" realized by |
+|---|---|
+| Subaerial slopes | `D_eff` weighting (`Df > Dc`) |
+| Lakes/depressions | per-fraction inlet bias + subaqueous `Df` |
+| Marine | per-fraction `Gmar` + subaqueous `Df` |
+
+---
+
+## 8. Lake / depression deposition (`sedplex`)
+
+Continental closed-depression deposition is a third depositional environment,
+separate from river transport and the marine (`seaplex`) clinoforms. The existing
+machinery already has the two end-members dual lithology needs:
+
+- **`_bottomUpDelta`** (`sedplex.py:230`) — deepest-first fill → the **fine /
+  depocenter** path.
+- **`_diffuseLargePit`** (`sedplex.py:385`) + inlet bias (`nl_pit_inlet_bias`,
+  `inputparser.py:494`) → the **coarse / inlet-delta** path.
+- **`_moveDownstream`** (`sedplex.py:84`) — pit fill + overspill cascade.
+
+Dual-lithology deposition is therefore **not new geometry** — it splits the per-
+pit deposited volume `depo → depoC, depoF` and routes each through the existing
+path, with `pitInletBias` per fraction (coarse high, fine ~0). New work:
+
+1. **Per-fraction pit budget** — carry `vSedC`/`vSedF` through `_moveDownstream`;
+   both fractions draw down the shared `self.pitVol` accommodation while placing
+   coarse-at-inlet and fine-in-depocenter, conserving total = `pitVol`.
+2. **Per-fraction deposit shape** — coarse → `_diffuseLargePit`, fine →
+   `_bottomUpDelta`.
+3. **Fine-enriched overspill** — the excess `eV` overspilling a filled lake
+   (`sedplex.py:118-126`) carries composition; coarse is largely trapped, so
+   overspill is fine-enriched (and may bypass downstream).
+4. **Fresh porosity** — lacustrine coarse → `phi0c`, fine → `phi0f` (feeds the
+   per-fraction compaction).
+5. **Per-fraction mass conservation across the cascade** — the spillover cascade
+   (`step>0`) and the lake-evap budget (`flowplex.py:364-375`, applied at
+   `step==0` only) must conserve each fraction independently. This is the
+   lacustrine analog of the documented marine terminal-sink leak (`AGENTS.md` >
+   Fixed > Marine sediment leak).
+
+---
+
+## 9. Phased implementation plan
+
+Land **Phases 0–2 + 4–5 first as a co-transport increment** (composition tracked,
+fines compact differently, routed *with* coarse), get it green, **then** do the
+separate-transport Phase 3 as a focused second PR with a full regression run. This
+de-risks the routing surgery.
+
+| Phase | Scope | Files | Risk |
+|---|---|---|---|
+| **0** | Flag + `_extraStrata` parser + backward-compat guard. *Acceptance: dual-off run bitwise-identical.* | `inputparser.py`, `AGENTS.md` | low |
+| **1** | Allocate `stratHf`/`phiF` (both branches of `readStratLayers`); write/restore in I/O + XDMF entries | `stratplex.py:45-103`, `outmesh.py` | low |
+| **2** | `_surfaceComposition()` helper; K-blend hook; eroded-mass split in `erodeStrat` | `stratplex.py` | medium |
+| **4** | Per-fraction deposition (`deposeStrat`) + per-fraction compaction (`_depthPorosity`/`getCompaction`) | `stratplex.py:146-345` | medium |
+| **5** | Stratal advection: `strataonesed` → `stratathreesed` (weathered slot = 0) | `stratplex.py:347-393` | medium |
+| **3a** | River routing: split `vSed → vSedC/vSedF` in `updateSedLoad`/`_getSedFlux` | `sedplex.py:46-83` | **high** |
+| **3b** | Lacustrine/pit deposition (Section 8) | `sedplex.py` | **high** |
+| **3c** | Marine routing: per-fraction `Gmar` in `_distOcean`/`_depMarineSystem` | `seaplex.py` | **high** |
+| **6** | Tests (Section 10) | `tests/`, `benchmarks/` | — |
+
+Phase 3 touches the high-risk modules (`flowplex`, `sedplex`, `seaplex`,
+`unstructuredmesh`) — it is ~70% of the effort/risk. Phases 0–2, 4–5 are mostly
+local to `stratplex`/`inputparser`/`outmesh`.
+
+---
+
+## 10. AGENTS.md contracts to honor
+
+- **`destroy_DMPlex` registration** (`unstructuredmesh.py:738-799`): any new
+  persistent Vec (`vSedF`, etc.) must be added to the destroy list or it leaks.
+- **`i`-suffix flow arrays**: SPL/sed kernels must use `rcvIDi`/`fMati`/etc.
+  (pre-fill snapshot), not the live `rcvID`/`fMat`.
+- **`Eb`/`EbLocal` thickness-rate sign convention** (positive deposition): both
+  fractions follow it; mirror the `sedplex._getSedFlux` negate-for-upstream quirk
+  per fraction.
+- **Scratch Vec contract**: document any `self.tmp`/`tmpL`/`tmp1`/`h`/`hl`/`dh`
+  reuse in new method docstrings; leave them in a defined state on exit.
+- **KSP/SNES/TS lifecycle**: prefer reusing existing cached solvers with node-
+  varying coefficients over adding new ones; any genuinely new cached solver →
+  add to `destroy_DMPlex`.
+- **Forcing/DataFrame named access**, **constants in `constants.py`**, **version
+  bump lockstep** — as per the standing rules.
+
+---
+
+## 11. Tests (Phase 6)
+
+1. **Dual-off reproduces single-fraction** bitwise (regression guard for the flag).
+2. **Per-fraction mass conservation** on the `minimal` global-sphere fixture
+   (closed domain; analog of `test_mass_conservation`) — assert eroded == deposited
+   per fraction to the documented floor tolerance.
+3. **Fines deposit more distally than coarse** (river → lake/marine partitioning).
+4. **Diffuse-through-a-compositional-boundary** fixture — bounds the explicit
+   `D_eff` lag (Section 6).
+5. `model.destroy()` in `try/finally`; benchmarks marked `@slow @benchmark` with
+   `pytest.importorskip` for scipy/matplotlib.
+
+---
+
+## 12. Open decisions
+
+- Whether to ship a dedicated `stratatwosed` Fortran kernel (faster, cleaner) or
+  keep reusing `stratathreesed` with a zeroed slot (no f2py build change). Start
+  with reuse.
+- Whether transport-limited SPL gets per-fraction coupled solves (option B,
+  Section 5) or stays deferred-to-sedplex (option A). Start with A.
+- Marine `fine_efficiency` vs lacustrine `pitInletBias`: kept as separate tunables
+  (different energy regimes) but documented as a pair.

--- a/docs/DESIGN_DUAL_LITHOLOGY.md
+++ b/docs/DESIGN_DUAL_LITHOLOGY.md
@@ -23,10 +23,12 @@ in `docs/tech_guide/strat.rst` once shipped.
 | Composition source | **Per stratigraphic layer** — each layer carries its own coarse/fine split; eroded material inherits the composition of the layer(s) it came from |
 | Transport | **Separate** — fines travel farther (distal basin / depocenter); coarse stays proximal |
 | Lake/depression behaviour | Coarse builds **inlet deltas**, fines settle in the **depocenter**; fine-enriched overspill may bypass downstream while coarse is trapped |
-| Fortran kernel | Reuse existing **`stratathreesed`** (`fortran/functions.F90:1905`, bound in `functions.pyf:195`) with the weathered slot zeroed; dedicated 2-sed kernel is a later optimization |
+| Fortran kernel | **Call `strataonesed` twice** (once for the total/coarse pile, once for the fine pile) — no Fortran change. NOT `stratathreesed`: it treats its extra fields as 0–1 fractions and renormalises (`functions.F90:1968`), which conflicts with the bulk-thickness representation used here. |
 
-The dormant `stratathreesed` 3-fraction kernel already exists but is never called
-(today only `strataonesed` is, `stratplex.py:13,363`). This design wires up the
+The dormant `stratathreesed` 3-fraction kernel exists but is never called and
+its fraction semantics don't match this design's bulk-thickness `stratHf`;
+Phase 5 reuses `strataonesed` (already bound, `stratplex.py:13`) a second time
+for the fine pile instead. This design wires up the
 2-fraction subset of it.
 
 ---
@@ -57,20 +59,34 @@ input files still load unchanged.
 strata:
   dual: True                          # default False -> current single-fraction path
   coarse: {phi0: 0.49, z0: 3700.}     # coarse porosity-depth (today's phi0s/z0s = coarse)
-  fine:   {phi0: 0.63, z0: 1960.}     # fines: higher surface porosity, shallower decay
+  fine:   {phi0: 0.63, z0: 1960., k_factor: 1.0}   # fines: porosity-depth + erodibility ratio
   bedrock_coarse_frac: 0.5            # composition of the layer-0 bedrock sentinel
   # transport / deposition contrast (the "fines travel farther" knobs):
   fine_efficiency: <factor>           # marine: per-fraction Gmar (fine deposits less readily)
   pitInletBias: {coarse: 0.5, fine: 0.0}   # lacustrine: coarse delta vs fine depocenter
-  Dc: <coeff>                         # subaerial + subaqueous diffusivity, coarse
-  Df: <coeff>                         # ... fine (Df > Dc)
+  fine_diff_factor: 1.0               # fine diffusivity relative to coarse (1.0 = no contrast)
 ```
+
+**Diffusivity contrast is a multiplier, not a replacement.** goSPL already has
+the base diffusion coefficients `hillslopeKa` (→ `self.Cda`, subaerial linear),
+`hillslopeKm` (→ `self.Cdm`, subaqueous linear), and `nonlinKm` (→ `self.nlK`,
+non-linear) — all grain-size-agnostic today. `fine_diff_factor` layers the
+lithology contrast on top of whichever base coefficient a cell uses:
+
+> `Cd_eff = Cd_base * (fc + ff * fine_diff_factor)`,  with `Cd_base ∈ {Cda, Cdm, nlK}`.
+
+So the existing land/sea/linear/non-linear structure is untouched;
+`fine_diff_factor == 1.0` (default) or `dual: False` ⇒ `Cd_eff == Cd_base`
+(byte-identical). This mirrors `fine.k_factor` for erodibility — one
+`_surfaceComposition()` feeds both blends. (Earlier drafts used absolute
+`Dc`/`Df`; dropped because they would duplicate and risk contradicting
+`hillslopeKa`/`hillslopeKm`/`nonlinKm`.)
 
 Parsed by a new `_extraStrata` method in `tools/inputparser.py`, following the
 **mandatory `_extra*` continuation convention** (add it to the `_extra*` table in
-`AGENTS.md`). Sets `self.stratLith`, the two porosity curves, `fine_efficiency`,
-per-fraction inlet bias, and `Dc`/`Df`. All keys default such that `dual: False`
-reproduces current behaviour.
+`AGENTS.md`). Sets `self.stratLith`, the two porosity curves, `fine_k_factor`,
+`fine_efficiency`, per-fraction inlet bias, and `fine_diff_factor`. All keys
+default such that `dual: False` reproduces current behaviour.
 
 ---
 
@@ -90,7 +106,7 @@ This single helper feeds **all three** consumers:
    `_surfaceK`.
 2. **Eroded-mass split** — `erodeStrat` splits the eroded solid by the consumed
    layers' composition (Section 6).
-3. **Diffusivity blend** — hillslope `D_eff = fc·Dc + ff·Df` (Section 7).
+3. **Diffusivity blend** — hillslope `Cd_eff = Cd_base*(fc + ff*fine_diff_factor)` (Section 7).
 
 ---
 
@@ -144,29 +160,38 @@ Mirror the existing negative-thickness clamp (`stratplex.py:226-228`) for
 ## 7. Diffusion (hillslope + subaqueous)
 
 Today hillslope is **single-rate** for both grain sizes (`hillslope.py:64`).
-Add per-class `Dc`/`Df` and evaluate via **composition-weighted effective
-diffusivity in a single solve**:
+goSPL already has the base diffusivities `Cda`/`Cdm` (linear land/marine, YAML
+`hillslopeKa`/`hillslopeKm`) and `nlK` (non-linear, `nonlinKm`). Add the
+grain-size contrast as a **dimensionless multiplier** `fine_diff_factor` (NOT a
+new absolute coefficient — see §3) and evaluate via **composition-weighted
+effective diffusivity in a single solve**:
 
-- `D_eff = fc·Dc + ff·Df` from `_surfaceComposition()`; the diffused flux carries
-  the **donor cell's composition** into `erodeStrat`/`deposeStrat`.
+- `Cd_eff = Cd_base * (fc + ff*fine_diff_factor)`, with `fc/ff` from
+  `_surfaceComposition()` and `Cd_base ∈ {Cda, Cdm, nlK}` (the cell's existing
+  land/marine/non-linear coefficient). The diffused flux carries the **donor
+  cell's composition** into `erodeStrat`/`deposeStrat`.
 - **Drop-in** to the existing solvers — the FV scheme already supports node-
   varying diffusivity (the nonlinear hillslope varies D by slope via
-  `Dlimit`/`dexp`); composition is just a multiplicative factor. **No new cached
-  solver** (so no `destroy_DMPlex` churn) and **no two-field nonlinear coupling**.
+  `Dlimit`/`dexp`); composition is just another multiplicative factor. **No new
+  cached solver** (so no `destroy_DMPlex` churn) and **no two-field nonlinear
+  coupling**.
+- Neutral by construction: `fine_diff_factor == 1.0` or `dual: False` ⇒
+  `Cd_eff == Cd_base`, byte-identical to today. Mirrors `fine.k_factor`.
 - A genuine two-field separate-D solve is more accurate but much heavier; offer
   as a future opt-in only.
 
-**Subaqueous diffusion is where the D-contrast does the real work.** The marine +
+**Subaqueous diffusion is where the contrast does the real work.** The marine +
 lake diffusion path (cached `_ts_marine`, `_diffuseImplicit` in `hillslope.py`)
-with `Df > Dc` is *the mechanism* by which fines spread to the depocenter while
-coarse stays proximal — i.e. it implements "fines travel farther" consistently
-with the lacustrine inlet-bias and marine `Gmar`:
+with `fine_diff_factor > 1` (on the `Cdm`/`nlK` base) is *the mechanism* by which
+fines spread to the depocenter while coarse stays proximal — i.e. it implements
+"fines travel farther" consistently with the lacustrine inlet-bias and marine
+`Gmar`:
 
 | Domain | "Fines travel farther" realized by |
 |---|---|
-| Subaerial slopes | `D_eff` weighting (`Df > Dc`) |
-| Lakes/depressions | per-fraction inlet bias + subaqueous `Df` |
-| Marine | per-fraction `Gmar` + subaqueous `Df` |
+| Subaerial slopes | `Cd_eff` weighting on `Cda` (`fine_diff_factor > 1`) |
+| Lakes/depressions | per-fraction inlet bias + subaqueous `Cd_eff` |
+| Marine | per-fraction `Gmar` + subaqueous `Cd_eff` (`Cdm`/`nlK` base) |
 
 ---
 
@@ -217,7 +242,7 @@ de-risks the routing surgery.
 | **1** | Allocate `stratHf`/`phiF` (both branches of `readStratLayers`); write/restore in I/O + XDMF entries | `stratplex.py:45-103`, `outmesh.py` | low |
 | **2** | `_surfaceComposition()` helper; K-blend hook; eroded-mass split in `erodeStrat` | `stratplex.py` | medium |
 | **4** | Per-fraction deposition (`deposeStrat`) + per-fraction compaction (`_depthPorosity`/`getCompaction`) | `stratplex.py:146-345` | medium |
-| **5** | Stratal advection: `strataonesed` → `stratathreesed` (weathered slot = 0) | `stratplex.py:347-393` | medium |
+| **5** | Stratal advection: second `strataonesed` call for the fine pile (`stratHf`, `phiF`) | `stratplex.py` (`stratalRecord`) | medium |
 | **3a** | River routing: split `vSed → vSedC/vSedF` in `updateSedLoad`/`_getSedFlux` | `sedplex.py:46-83` | **high** |
 | **3b** | Lacustrine/pit deposition (Section 8) | `sedplex.py` | **high** |
 | **3c** | Marine routing: per-fraction `Gmar` in `_distOcean`/`_depMarineSystem` | `seaplex.py` | **high** |
@@ -264,9 +289,10 @@ local to `stratplex`/`inputparser`/`outmesh`.
 
 ## 12. Open decisions
 
-- Whether to ship a dedicated `stratatwosed` Fortran kernel (faster, cleaner) or
-  keep reusing `stratathreesed` with a zeroed slot (no f2py build change). Start
-  with reuse.
+- Whether to ship a dedicated `stratatwosed` Fortran kernel (one pass instead of
+  two `strataonesed` calls — interpolates the redundant elevation only once).
+  Implemented Phase 5 with two `strataonesed` calls (no f2py change); a fused
+  kernel is a later micro-optimization.
 - Whether transport-limited SPL gets per-fraction coupled solves (option B,
   Section 5) or stays deferred-to-sedplex (option A). Start with A.
 - Marine `fine_efficiency` vs lacustrine `pitInletBias`: kept as separate tunables

--- a/gospl/eroder/SPL.py
+++ b/gospl/eroder/SPL.py
@@ -57,7 +57,9 @@ class SPL(object):
         # Per-node erodibility multiplier from the top of the local
         # stratigraphic column (1.0 = use self.K as-is). Bedrock layers
         # imposed via the initial-strata `stratK` field show up here.
-        surfK = self._surfaceK()
+        # Fold in the dual-lithology erodibility blend (1.0 everywhere when
+        # single-fraction, so behaviour is unchanged): K_eff = K*surfK*litK.
+        surfK = self._surfaceK() * self._surfaceLithoK()
 
         # Incorporate the effect of local mean annual precipitation rate on erodibility
         if self.sedfacVal is not None:

--- a/gospl/eroder/nlSPL.py
+++ b/gospl/eroder/nlSPL.py
@@ -186,7 +186,9 @@ class nlSPL(object):
         # Per-node erodibility multiplier from the top of the local
         # stratigraphic column (1.0 = use self.K as-is). Bedrock layers
         # imposed via the initial-strata `stratK` field show up here.
-        surfK = self._surfaceK()
+        # Fold in the dual-lithology erodibility blend (1.0 everywhere when
+        # single-fraction, so behaviour is unchanged): K_eff = K*surfK*litK.
+        surfK = self._surfaceK() * self._surfaceLithoK()
 
         # Incorporate the effect of local mean annual precipitation rate on erodibility
         if self.sedfacVal is not None:
@@ -271,7 +273,9 @@ class nlSPL(object):
 
         # Per-node erodibility multiplier from the top of the local
         # stratigraphic column (1.0 = use self.K as-is).
-        surfK = self._surfaceK()
+        # Fold in the dual-lithology erodibility blend (1.0 everywhere when
+        # single-fraction, so behaviour is unchanged): K_eff = K*surfK*litK.
+        surfK = self._surfaceK() * self._surfaceLithoK()
 
         # Incorporate the effect of local mean annual precipitation rate on erodibility
         if self.sedfacVal is not None:

--- a/gospl/eroder/soilSPL.py
+++ b/gospl/eroder/soilSPL.py
@@ -177,7 +177,9 @@ class soilSPL(object):
         # stratigraphic column (1.0 = use self.K as-is). Only scales the
         # *bedrock* SPL coefficient; the soil-layer K is governed by
         # `self.Ksoil` and is left unchanged.
-        surfK = self._surfaceK()
+        # Fold in the dual-lithology erodibility blend (1.0 everywhere when
+        # single-fraction, so behaviour is unchanged): K_eff = K*surfK*litK.
+        surfK = self._surfaceK() * self._surfaceLithoK()
 
         # Incorporate the effect of local mean annual precipitation rate on erodibility (for soil and bedrock)
         if self.sedfacVal is not None:

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -123,11 +123,14 @@ class STRAMesh(object):
             self.phiS[:, 0] = self.phi0s
             self.bedrockLay = 1          # layer 0 is the infinite-bedrock sentinel
 
-            # Dual-lithology fine-fraction fields (all-coarse to start; the
-            # bedrock-sentinel composition split is applied in Phase 2).
+            # Dual-lithology fine-fraction fields. The infinite-bedrock
+            # sentinel layer is split into coarse/fine by bedrock_coarse_frac
+            # so material eroded from bedrock inherits a defined composition.
             if self.stratLith:
                 self.stratHf = np.zeros((self.lpoints, self.stratNb), dtype=np.float64)
                 self.phiF = np.zeros((self.lpoints, self.stratNb), dtype=np.float64)
+                self.stratHf[:, 0] = BEDROCK_SENTINEL * (1.0 - self.bedrock_coarse_frac)
+                self.phiF[:, 0] = self.phi0f
 
         return
     
@@ -171,6 +174,53 @@ class STRAMesh(object):
         rows = np.arange(sK.shape[0])
         out[any_valid] = sK[rows[any_valid], top_idx[any_valid]]
         return out
+
+    def _surfaceComposition(self):
+        """
+        Return the per-node coarse fraction ``fc`` (by bulk thickness) of
+        the topmost non-empty stratigraphic layer; the fine fraction is
+        ``1 - fc``.
+
+        Returns all-ones (all coarse) when dual lithology is disabled or the
+        fine pile is unallocated, so single-fraction callers are unchanged.
+        Shared hook for the SPL erodibility blend (`_surfaceLithoK`) and the
+        hillslope diffusivity blend (see DESIGN_DUAL_LITHOLOGY.md).
+        """
+        if not self.stratLith or self.stratHf is None or self.stratNb == 0:
+            return np.ones(self.lpoints, dtype=np.float64)
+
+        H = self.stratH[:, : self.stratStep + 1]
+        Hf = self.stratHf[:, : self.stratStep + 1]
+        mask = H > 0
+        # Topmost non-empty layer per node (reverse-then-argmax, as _surfaceK).
+        rev = mask[:, ::-1]
+        any_valid = rev.any(axis=1)
+        top_from_right = np.argmax(rev, axis=1)
+        top_idx = H.shape[1] - 1 - top_from_right
+
+        fc = np.ones(self.lpoints, dtype=np.float64)
+        rows = np.arange(H.shape[0])
+        Htop = H[rows, top_idx]
+        Hftop = Hf[rows, top_idx]
+        valid = any_valid & (Htop > 0)
+        fc[valid] = 1.0 - (Hftop[valid] / Htop[valid])
+        np.clip(fc, 0.0, 1.0, out=fc)
+        return fc
+
+    def _surfaceLithoK(self):
+        """
+        Per-node erodibility multiplier from the exposed surface
+        composition: ``fc + (1 - fc) * fine_k_factor``.
+
+        Equals 1.0 everywhere when dual lithology is off (or
+        ``fine_k_factor == 1``, i.e. no lithology contrast), so it composes
+        multiplicatively with ``_surfaceK`` in the SPL flavours without
+        altering single-fraction behaviour.
+        """
+        if not self.stratLith:
+            return np.ones(self.lpoints, dtype=np.float64)
+        fc = self._surfaceComposition()
+        return fc + (1.0 - fc) * self.fine_k_factor
 
     def deposeStrat(self):
         """
@@ -217,23 +267,50 @@ class STRAMesh(object):
         nids = np.where(ero < 0)[0]
         if len(nids) == 0:
             self.thCoarse = np.zeros(self.lpoints)
+            if self.stratLith:
+                self.thFine = np.zeros(self.lpoints)
             return
 
         # Cumulative thickness for each node
+        if self.stratLith:
+            # Inflate the fine pile in proportion to layer 0's CURRENT fine
+            # fraction so the sentinel never alters that layer's composition
+            # (for the infinite-bedrock case this fraction is 1-bedrock_coarse_frac;
+            # for a real basal layer it is its own fine ratio, i.e. 0 if all coarse).
+            H0 = self.stratH[nids, 0]
+            sentFine = BEDROCK_SENTINEL * np.divide(
+                self.stratHf[nids, 0], H0, out=np.zeros_like(H0), where=H0 > 0
+            )
         self.stratH[nids, 0] += BEDROCK_SENTINEL
+        if self.stratLith:
+            self.stratHf[nids, 0] += sentFine
         cumThick = np.cumsum(self.stratH[nids, self.stratStep :: -1], axis=1)[:, ::-1]
         boolMask = cumThick < -ero[nids].reshape((len(nids), 1))
         mask = boolMask.astype(int)
 
         thickS = self.stratH[nids, 0 : self.stratStep + 1]
-        thCoarse = thickS * (1.0 - self.phiS[nids, 0 : self.stratStep + 1])
-        thCoarse = np.sum((thCoarse * mask), axis=1)
+        if self.stratLith:
+            # Each layer's bulk thickness splits into coarse and fine; each
+            # fraction yields its own solid phase (1 - its own porosity).
+            fineTh = self.stratHf[nids, 0 : self.stratStep + 1]
+            coarseTh = thickS - fineTh
+            thCoarse = coarseTh * (1.0 - self.phiS[nids, 0 : self.stratStep + 1])
+            thFine = fineTh * (1.0 - self.phiF[nids, 0 : self.stratStep + 1])
+            thCoarse = np.sum((thCoarse * mask), axis=1)
+            thFine = np.sum((thFine * mask), axis=1)
+        else:
+            thCoarse = thickS * (1.0 - self.phiS[nids, 0 : self.stratStep + 1])
+            thCoarse = np.sum((thCoarse * mask), axis=1)
 
         # Clear all stratigraphy points which are eroded
         cumThick[boolMask] = 0.0
         tmp = self.stratH[nids, : self.stratStep + 1]
         tmp[boolMask] = 0
         self.stratH[nids, : self.stratStep + 1] = tmp
+        if self.stratLith:
+            tmpf = self.stratHf[nids, : self.stratStep + 1]
+            tmpf[boolMask] = 0
+            self.stratHf[nids, : self.stratStep + 1] = tmpf
 
         # Erode remaining stratal layers
         # Get non-zero top layer number
@@ -241,17 +318,41 @@ class STRAMesh(object):
         eroVal = cumThick[np.arange(len(nids)), eroLayNb] + ero[nids]
 
         self.thCoarse = np.zeros(self.lpoints)
-        # From sand thickness extract the solid phase that is eroded from this last layer
-        tmp = self.stratH[nids, eroLayNb] - eroVal
+        # From the partially eroded top layer extract the solid phase removed.
+        H_old = self.stratH[nids, eroLayNb]
+        tmp = H_old - eroVal
         tmp[tmp < 1.0e-8] = 0.0  # TODO-REFACTOR: value matches DISCHARGE_FLOOR but distinct role (thickness numerical-noise floor); do not replace
-        # Define the uncompacted sand thickness that will be deposited dowstream
-        thCoarse += tmp * (1.0 - self.phiS[nids, eroLayNb])
-        self.thCoarse[nids] = thCoarse / (1.0 - self.phi0s)
-        self.thCoarse[self.thCoarse < 0.0] = 0.0
+        if self.stratLith:
+            self.thFine = np.zeros(self.lpoints)
+            Hf_old = self.stratHf[nids, eroLayNb]
+            # Well-mixed layer: coarse/fine bulk are removed in proportion to
+            # the layer composition; the remainder keeps the same ratio.
+            frac = np.divide(tmp, H_old, out=np.zeros_like(tmp), where=H_old > 0)
+            coarse_rm = (H_old - Hf_old) * frac
+            fine_rm = Hf_old * frac
+            thCoarse = thCoarse + coarse_rm * (1.0 - self.phiS[nids, eroLayNb])
+            thFine = thFine + fine_rm * (1.0 - self.phiF[nids, eroLayNb])
+            # Uncompacted thickness deposited downstream, per fraction, using
+            # each lithology's surface porosity.
+            self.thCoarse[nids] = thCoarse / (1.0 - self.phi0c)
+            self.thFine[nids] = thFine / (1.0 - self.phi0f)
+            self.thCoarse[self.thCoarse < 0.0] = 0.0
+            self.thFine[self.thFine < 0.0] = 0.0
+            # Remaining fine in the partial layer scales with remaining total.
+            self.stratHf[nids, eroLayNb] = Hf_old * np.divide(
+                eroVal, H_old, out=np.zeros_like(eroVal), where=H_old > 0
+            )
+        else:
+            # Define the uncompacted sand thickness that will be deposited dowstream
+            thCoarse += tmp * (1.0 - self.phiS[nids, eroLayNb])
+            self.thCoarse[nids] = thCoarse / (1.0 - self.phi0s)
+            self.thCoarse[self.thCoarse < 0.0] = 0.0
 
         # Update thickness of top stratigraphic layer
         self.stratH[nids, eroLayNb] = eroVal
         self.stratH[nids, 0] -= BEDROCK_SENTINEL
+        if self.stratLith:
+            self.stratHf[nids, 0] -= sentFine
         neg = self.stratH < 0
         self.stratH[neg] = 0.0
         self.phiS[neg] = 0.0
@@ -264,7 +365,20 @@ class STRAMesh(object):
         self.stratK[:, : self.stratStep + 1] = self._fillZeroPorosity(
             self.stratK[:, : self.stratStep + 1]
         )
+        if self.stratLith:
+            top = self.stratStep + 1
+            self.stratHf[neg] = 0.0
+            self.phiF[neg] = 0.0
+            np.clip(self.stratHf, 0.0, None, out=self.stratHf)
+            # Fine bulk can never exceed the layer total thickness.
+            np.minimum(
+                self.stratHf[:, :top], self.stratH[:, :top],
+                out=self.stratHf[:, :top],
+            )
+            self.phiF[:, :top] = self._fillZeroPorosity(self.phiF[:, :top])
         self.thCoarse /= self.dt
+        if self.stratLith:
+            self.thFine /= self.dt
 
         return
 

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -228,6 +228,13 @@ class STRAMesh(object):
 
         - thickness of each stratigrapic layer `stratH` accounting for both erosion & deposition events.
         - porosity of sediment `phiS` in each stratigraphic layer computed at center of each layer.
+
+        In dual-lithology mode the deposit is split into a coarse and a fine
+        fraction. The fine fraction is the step's **global eroded composition**
+        (``Σ thFine / Σ (thCoarse + thFine)`` over the domain) — a co-transport
+        placeholder: fines are assumed to travel with coarse so a deposit
+        carries the bulk source composition. Phase 3 (separate transport)
+        replaces this scalar with a spatially-resolved routed fine deposit.
         """
 
         self.dm.globalToLocal(self.tmp, self.tmpL)
@@ -235,7 +242,20 @@ class STRAMesh(object):
         depo[depo < 1.0e-4] = 0.0
         self.stratH[:, self.stratStep] += depo
         ids = np.where(depo > 0)[0]
-        self.phiS[ids, self.stratStep] = self.phi0s
+        if self.stratLith:
+            # Area-weighted global eroded fine fraction (collective: every
+            # rank participates, matching the MPI contract).
+            cV = float(np.sum(self.thCoarse * self.larea))
+            fV = float(np.sum(self.thFine * self.larea))
+            cV = MPI.COMM_WORLD.allreduce(cV, op=MPI.SUM)
+            fV = MPI.COMM_WORLD.allreduce(fV, op=MPI.SUM)
+            ff_dep = fV / (cV + fV) if (cV + fV) > 0.0 else 0.0
+            self.stratHf[:, self.stratStep] += depo * ff_dep
+            # Fresh deposit carries each lithology's surface porosity.
+            self.phiS[ids, self.stratStep] = self.phi0c
+            self.phiF[ids, self.stratStep] = self.phi0f
+        else:
+            self.phiS[ids, self.stratStep] = self.phi0s
         # Freshly deposited sediment carries the default erodibility (no
         # multiplier). If you want re-deposited sediment to keep its
         # source-layer K, this is the line to revisit.
@@ -404,6 +424,9 @@ class STRAMesh(object):
         :return: newH updated sedimentary layer thicknesses after compaction
         """
 
+        if self.stratLith:
+            return self._depthPorosityDual(depth)
+
         # Depth-porosity functions
         phiS = self.phi0s * np.exp(depth / self.z0s)
         phiS = np.minimum(phiS, self.phiS[:, : self.stratStep + 1])
@@ -435,6 +458,76 @@ class STRAMesh(object):
         if self.memclear:
             del phiS, solidPhase
             del ids, tmpS, tot
+            gc.collect()
+
+        return newH
+
+    def _depthPorosityDual(self, depth):
+        """
+        Dual-lithology depth-porosity / compaction. Each fraction (coarse,
+        fine) compacts on its own porosity-depth curve; the layer's new
+        thickness is the sum of the two recompacted bulk thicknesses, and the
+        fine pile ``stratHf`` is updated consistently.
+
+        This is the headline physics of dual lithology: fine and coarse have
+        different compaction, so the same solid load yields a different
+        preserved thickness depending on the layer's grain mix.
+
+        :arg depth: depth below basement for each sedimentary layer
+        :return: newH updated layer thicknesses after compaction
+        """
+
+        top = self.stratStep + 1
+        phiS_cur = self.phiS[:, :top]
+        phiF_cur = self.phiF[:, :top]
+        H = self.stratH[:, :top]
+        Hf = self.stratHf[:, :top]
+        Hc = H - Hf
+
+        # Per-fraction depth-porosity, capped at the current value (porosity
+        # cannot increase on unloading — same assumption as single-fraction).
+        phiS_new = np.minimum(self.phi0c * np.exp(depth / self.z0c), phiS_cur)
+        phiF_new = np.minimum(self.phi0f * np.exp(depth / self.z0f), phiF_cur)
+
+        # Solid phase preserved per fraction.
+        coarseSolid = Hc * (1.0 - phiS_cur)
+        fineSolid = Hf * (1.0 - phiF_cur)
+
+        # Recompacted bulk thickness per fraction.
+        totC = 1.0 - phiS_new
+        totF = 1.0 - phiF_new
+        Hc_new = np.zeros_like(Hc)
+        Hf_new = np.zeros_like(Hf)
+        idc = totC > 0.0
+        idf = totF > 0.0
+        Hc_new[idc] = coarseSolid[idc] / totC[idc]
+        Hf_new[idf] = fineSolid[idf] / totF[idf]
+        Hc_new[Hc_new <= 0] = 0.0
+        Hf_new[Hf_new <= 0] = 0.0
+        newH = Hc_new + Hf_new
+
+        # Emptied layers carry no porosity.
+        empty = newH <= 0
+        phiS_new[empty] = 0.0
+        phiF_new[empty] = 0.0
+
+        # Freeze the bedrock sentinel layers (thickness + porosities unchanged).
+        if self.bedrockLay > 0:
+            b = self.bedrockLay
+            newH[:, :b] = H[:, :b]
+            Hf_new[:, :b] = Hf[:, :b]
+            phiS_new[:, :b] = phiS_cur[:, :b]
+            phiF_new[:, :b] = phiF_cur[:, :b]
+
+        phiS_new = self._fillZeroPorosity(phiS_new)
+        phiF_new = self._fillZeroPorosity(phiF_new)
+        self.phiS[:, :top] = phiS_new
+        self.phiF[:, :top] = phiF_new
+        self.stratHf[:, :top] = Hf_new
+
+        if self.memclear:
+            del phiS_new, phiF_new, coarseSolid, fineSolid
+            del Hc, Hf, Hc_new, Hf_new, totC, totF
             gc.collect()
 
         return newH

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -584,7 +584,12 @@ class STRAMesh(object):
         """
         Once the interpolation has been performed, the following function updates the stratigraphic records based on the advected mesh.
 
-        The function relies on fortran subroutines strataonesed.
+        The function relies on the fortran subroutine strataonesed. In
+        dual-lithology mode the fine pile (`stratHf`, `phiF`) is advected with
+        a second strataonesed call — `stratHf` is a bulk thickness, so the
+        plain weighted interpolation applies directly (the unused `stratathreesed`
+        kernel instead treats its extra fields as 0–1 fractions and renormalises
+        them, which does not match the thickness representation here).
 
         :arg indices: indices of the closest nodes used for interpolation
         :arg weights: weights based on the distances to closest nodes
@@ -611,6 +616,25 @@ class STRAMesh(object):
             nstratH[onIDs, :] = loc_stratH[indices[onIDs, 0], :]
             nphiS[onIDs, :] = loc_phiS[indices[onIDs, 0], :]
 
+        if self.stratLith:
+            # Advect the fine pile with the same interpolation (stratHf as
+            # thickness, phiF as porosity); the re-interpolated elevation is
+            # identical to nstratZ above and discarded.
+            loc_stratHf = self.stratHf[:, : self.stratStep]
+            loc_phiF = self.phiF[:, : self.stratStep]
+            nstratHf, _, nphiF = strataonesed(
+                self.lpoints,
+                self.stratStep,
+                indices,
+                weights,
+                loc_stratHf,
+                loc_stratZ,
+                loc_phiF,
+            )
+            if len(onIDs) > 0:
+                nstratHf[onIDs, :] = loc_stratHf[indices[onIDs, 0], :]
+                nphiF[onIDs, :] = loc_phiF[indices[onIDs, 0], :]
+
         # Updates stratigraphic records after mesh advection on the edges of each partition
         # to ensure that all stratigraphic information on the adjacent nodes of the neighbouring
         # partition are equals on all processors sharing a common number of nodes.
@@ -625,5 +649,13 @@ class STRAMesh(object):
             self.tmp.setArray(nphiS[:, k])
             self.dm.globalToLocal(self.tmp, self.tmpL)
             self.phiS[:, k] = self.tmpL.getArray().copy()
+
+            if self.stratLith:
+                self.tmp.setArray(nstratHf[:, k])
+                self.dm.globalToLocal(self.tmp, self.tmpL)
+                self.stratHf[:, k] = self.tmpL.getArray().copy()
+                self.tmp.setArray(nphiF[:, k])
+                self.dm.globalToLocal(self.tmp, self.tmpL)
+                self.phiF[:, k] = self.tmpL.getArray().copy()
 
         return

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -33,6 +33,12 @@ class STRAMesh(object):
         self.stratH = None
         self.stratZ = None
         self.phiS = None
+        # Dual-lithology (coarse/fine) layer fields. Allocated only when
+        # self.stratLith is True (see _extraStrata / DESIGN_DUAL_LITHOLOGY.md).
+        # stratHf = fine-fraction layer thickness (coarse = stratH - stratHf);
+        # phiF = fine porosity per layer (phiS then holds the coarse porosity).
+        self.stratHf = None
+        self.phiF = None
         # Per-layer erodibility multiplier (lpoints, stratNb). Effective K
         # at the surface = self.K * stratK[<top non-empty layer>]. Fresh
         # deposits and the bedrock sentinel default to 1.0 (no scaling).
@@ -81,6 +87,23 @@ class STRAMesh(object):
                     self.locIDs, 0 : self.initLay
                 ]
 
+            # Dual-lithology fine-fraction layer fields. Optional in the
+            # npstrata file (`strataHf`, `phiF`); absent -> all-coarse
+            # (fine thickness 0), so a single-fraction file still loads.
+            if self.stratLith:
+                self.stratHf = np.zeros((self.lpoints, self.stratNb), dtype=np.float64)
+                if "strataHf" in fileData.files:
+                    stratVal = fileData["strataHf"]
+                    self.stratHf[:, 0 : self.initLay] = stratVal[
+                        self.locIDs, 0 : self.initLay
+                    ]
+                self.phiF = np.zeros((self.lpoints, self.stratNb), dtype=np.float64)
+                if "phiF" in fileData.files:
+                    stratVal = fileData["phiF"]
+                    self.phiF[:, 0 : self.initLay] = stratVal[
+                        self.locIDs, 0 : self.initLay
+                    ]
+
             # All layers in the file are real sediment; no bedrock sentinel.
             self.bedrockLay = 0
 
@@ -99,6 +122,12 @@ class STRAMesh(object):
             self.stratH[:, 0] = BEDROCK_SENTINEL
             self.phiS[:, 0] = self.phi0s
             self.bedrockLay = 1          # layer 0 is the infinite-bedrock sentinel
+
+            # Dual-lithology fine-fraction fields (all-coarse to start; the
+            # bedrock-sentinel composition split is applied in Phase 2).
+            if self.stratLith:
+                self.stratHf = np.zeros((self.lpoints, self.stratNb), dtype=np.float64)
+                self.phiF = np.zeros((self.lpoints, self.stratNb), dtype=np.float64)
 
         return
     

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -1416,6 +1416,94 @@ class ReadYaml(object):
             self.phi0s = 0.49
             self.z0s = 3700.0
 
+        self._extraStrata()
+
+        return
+
+    def _extraStrata(self):
+        """
+        Parse the optional dual-lithology (coarse/fine) stratigraphy block.
+
+        Continuation of ``_readCompaction`` (the coarse porosity curve
+        defaults to the single-fraction ``compaction`` values, so a model
+        with ``strata: dual: False`` — or no ``strata`` block at all — runs
+        the existing single-fraction path bitwise-unchanged).
+
+        Sets ``self.stratLith`` (master opt-in flag) plus the per-lithology
+        parameters consumed by later phases (porosity-depth curves, bedrock
+        composition, marine fine transport efficiency, per-fraction lake
+        inlet bias, and subaerial/subaqueous diffusivities). All of these
+        are inert while ``self.stratLith`` is False.
+
+        Dual lithology is only meaningful when stratigraphy recording is on;
+        if requested with stratigraphy disabled (``self.stratNb == 0``) the
+        flag is forced back to False with a rank-0 warning.
+
+        See ``docs/DESIGN_DUAL_LITHOLOGY.md`` and AGENTS.md > The ``_extra*``
+        methods are mandatory continuations.
+        """
+
+        # Coarse lithology porosity-depth defaults to the single-fraction
+        # compaction curve so the dual-off path is unchanged. Fine lithology
+        # defaults to a higher surface porosity / shallower decay; both fine
+        # values are inert unless dual lithology is enabled.
+        self.phi0c = self.phi0s
+        self.z0c = self.z0s
+        self.phi0f = 0.63
+        self.z0f = 1960.0
+        self.bedrock_coarse_frac = 0.5
+        self.fine_efficiency = 0.5
+        self.pit_inlet_bias_coarse = 0.50
+        self.pit_inlet_bias_fine = 0.0
+        self.Dc = None
+        self.Df = None
+
+        # TODO-REFACTOR: complex except, needs manual review (outer-section: sets stratLith=False on missing "strata")
+        try:
+            strataDict = self.input["strata"]
+            self.stratLith = bool(strataDict.get("dual", False))
+
+            coarseDict = strataDict.get("coarse", {})
+            self.phi0c = coarseDict.get("phi0", self.phi0s)
+            self.z0c = coarseDict.get("z0", self.z0s)
+
+            fineDict = strataDict.get("fine", {})
+            self.phi0f = fineDict.get("phi0", self.phi0f)
+            self.z0f = fineDict.get("z0", self.z0f)
+
+            self.bedrock_coarse_frac = strataDict.get(
+                "bedrock_coarse_frac", self.bedrock_coarse_frac
+            )
+            self.fine_efficiency = strataDict.get("fine_efficiency", self.fine_efficiency)
+
+            biasDict = strataDict.get("pitInletBias", {})
+            if isinstance(biasDict, dict):
+                self.pit_inlet_bias_coarse = biasDict.get(
+                    "coarse", self.pit_inlet_bias_coarse
+                )
+                self.pit_inlet_bias_fine = biasDict.get("fine", self.pit_inlet_bias_fine)
+
+            self.Dc = strataDict.get("Dc", None)
+            self.Df = strataDict.get("Df", None)
+
+        except KeyError:
+            self.stratLith = False
+
+        # Dual lithology only makes sense when stratigraphy recording is on.
+        if self.stratLith and self.stratNb == 0:
+            if MPIrank == 0:
+                print(
+                    "Dual-lithology (strata: dual) requires stratigraphy to be "
+                    "enabled (set a positive `strat` interval in the time block); "
+                    "falling back to single-fraction sediment.",
+                    flush=True,
+                )
+            self.stratLith = False
+
+        # Clamp inlet-bias fractions to [0, 1] (mirrors nl_pit_inlet_bias).
+        self.pit_inlet_bias_coarse = min(1.0, max(0.0, self.pit_inlet_bias_coarse))
+        self.pit_inlet_bias_fine = min(1.0, max(0.0, self.pit_inlet_bias_fine))
+
         return
 
     def _readFlex(self):

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -1451,6 +1451,9 @@ class ReadYaml(object):
         self.z0c = self.z0s
         self.phi0f = 0.63
         self.z0f = 1960.0
+        # Fine erodibility relative to coarse: K_fine = K_coarse * fine_k_factor.
+        # 1.0 (default) = no lithology contrast in the SPL erodibility blend.
+        self.fine_k_factor = 1.0
         self.bedrock_coarse_frac = 0.5
         self.fine_efficiency = 0.5
         self.pit_inlet_bias_coarse = 0.50
@@ -1470,6 +1473,7 @@ class ReadYaml(object):
             fineDict = strataDict.get("fine", {})
             self.phi0f = fineDict.get("phi0", self.phi0f)
             self.z0f = fineDict.get("z0", self.z0f)
+            self.fine_k_factor = fineDict.get("k_factor", self.fine_k_factor)
 
             self.bedrock_coarse_frac = strataDict.get(
                 "bedrock_coarse_frac", self.bedrock_coarse_frac

--- a/gospl/tools/outmesh.py
+++ b/gospl/tools/outmesh.py
@@ -188,6 +188,27 @@ class WriteMesh(object):
                     :, : self.stratStep + 1
                 ]
 
+            # Dual-lithology fine-fraction fields. Only written when the
+            # dual coarse/fine option is enabled (self.stratHf allocated in
+            # readStratLayers); single-fraction outputs are unchanged.
+            if self.stratHf is not None:
+                f.create_dataset(
+                    "stratHf",
+                    shape=(self.lpoints, self.stratStep + 1),
+                    dtype="float64",
+                    compression="gzip",
+                )
+                f["stratHf"][:, : self.stratStep + 1] = self.stratHf[
+                    :, : self.stratStep + 1
+                ]
+                f.create_dataset(
+                    "phiF",
+                    shape=(self.lpoints, self.stratStep + 1),
+                    dtype="float64",
+                    compression="gzip",
+                )
+                f["phiF"][:, : self.stratStep + 1] = self.phiF[:, : self.stratStep + 1]
+
         MPIcomm.Barrier()
 
         if MPIrank == 0 and self.verbose:
@@ -497,6 +518,16 @@ class WriteMesh(object):
                     # behaviour for any pre-existing restart files.
                     self.stratK.fill(1.0)
                     self.stratK[:, : self.stratStep] = np.array(hf["/stratK"])
+                # Dual-lithology fine-fraction fields. Restarting a dual run
+                # from a single-fraction output (no /stratHf dataset) falls
+                # back to all-coarse zeros, so the restore stays robust.
+                if self.stratHf is not None:
+                    self.stratHf.fill(0.0)
+                    if "/stratHf" in hf:
+                        self.stratHf[:, : self.stratStep] = np.array(hf["/stratHf"])
+                    self.phiF.fill(0.0)
+                    if "/phiF" in hf:
+                        self.phiF[:, : self.stratStep] = np.array(hf["/phiF"])
 
         return
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -552,6 +552,67 @@ def test_dual_lithology_deposit_and_compaction():
     )
 
 
+def test_dual_lithology_advection_fine_pile():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 5 — stratalRecord advects the
+    fine pile (stratHf, phiF) alongside the total/coarse pile via a second
+    strataonesed call (NOT stratathreesed, whose extra fields are 0-1
+    fractions and renormalised — wrong for the bulk-thickness representation).
+
+    Uses an identity advection (each node maps to itself with weight 1) so
+    the records must come back unchanged, confirming the fine fields are
+    actually routed through the interpolation and written back.
+    """
+    stratplex = pytest.importorskip("gospl.sed.stratplex")
+
+    class _MockVec:
+        def __init__(self, n):
+            self._a = np.zeros(n)
+        def setArray(self, a):
+            self._a = np.asarray(a, dtype=np.float64).copy()
+        def getArray(self):
+            return self._a
+
+    class _MockDM:
+        def globalToLocal(self, src, dst):
+            dst.setArray(src.getArray())  # identity halo exchange
+
+    n = 4
+    m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
+    m.lpoints = n
+    m.stratStep = 2          # advect layers 0..1
+    m.stratLith = True
+    m.stratH = np.array([[5.0, 7.0, 0.0]] * n)
+    m.stratHf = np.array([[2.0, 3.0, 0.0]] * n)
+    m.stratZ = np.array([[-10.0, -3.0, 0.0]] * n)
+    m.phiS = np.array([[0.45, 0.48, 0.0]] * n)
+    m.phiF = np.array([[0.60, 0.62, 0.0]] * n)
+    m.tmp = _MockVec(n)
+    m.tmpL = _MockVec(n)
+    m.dm = _MockDM()
+
+    # Identity interpolation: 3 neighbours all = self, weights summing to 1.
+    indices = np.repeat(np.arange(n)[:, None], 3, axis=1)
+    weights = np.full((n, 3), 1.0 / 3.0)
+    onIDs = np.array([], dtype=int)
+
+    H0, Hf0 = m.stratH.copy(), m.stratHf.copy()
+    phiS0, phiF0 = m.phiS.copy(), m.phiF.copy()
+    m.stratalRecord(indices, weights, onIDs)
+
+    # Advected layers (0..stratStep-1) must be preserved by identity mapping.
+    s = slice(0, m.stratStep)
+    assert np.allclose(m.stratHf[:, s], Hf0[:, s]), (
+        "Fine pile thickness must round-trip through identity advection."
+    )
+    assert np.allclose(m.phiF[:, s], phiF0[:, s]), (
+        "Fine porosity must round-trip through identity advection."
+    )
+    # Coarse/total pile still correct (regression on the original behaviour).
+    assert np.allclose(m.stratH[:, s], H0[:, s])
+    assert np.allclose(m.phiS[:, s], phiS0[:, s])
+
+
 # ---------------------------------------------------------------------------
 # TEST 2c - channel-evap hook reduces FA (DESIGN_EVAPORATION.md §4 T1)
 # ---------------------------------------------------------------------------

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -467,6 +467,91 @@ def test_dual_lithology_erosion_split():
     assert np.allclose(m._surfaceLithoK(), 1.0), "K-blend must be neutral when off."
 
 
+def test_dual_lithology_deposit_and_compaction():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 4 — per-fraction deposition
+    (deposeStrat) and per-fraction compaction (_depthPorosityDual).
+
+    Deposition: the fresh layer accumulates a fine fraction equal to the
+    step's global eroded composition, with each lithology's surface porosity.
+
+    Compaction (the headline physics): each fraction compacts on its own
+    porosity-depth curve, conserving its solid phase while fines lose more
+    bulk thickness than coarse at the same burial depth.
+    """
+    from gospl.sed import stratplex
+    from mpi4py import MPI
+
+    class _StubVec:
+        def __init__(self, arr):
+            self._a = np.asarray(arr, dtype=np.float64)
+        def getArray(self):
+            return self._a
+        def setArray(self, a):
+            self._a = np.asarray(a, dtype=np.float64)
+
+    class _StubDM:
+        def globalToLocal(self, g, l):
+            l.setArray(g.getArray().copy())
+
+    # ---- Deposition: 4 m deposit, global eroded fine fraction = 1/(3+1) ----
+    m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
+    m.lpoints, m.stratNb, m.stratStep = 1, 2, 1
+    m.stratLith = True
+    m.memclear = False
+    m.phi0c, m.phi0f = 0.49, 0.63
+    m.larea = np.array([1.0])
+    m.thCoarse = np.array([3.0])
+    m.thFine = np.array([1.0])
+    m.stratH = np.zeros((1, 2))
+    m.stratHf = np.zeros((1, 2))
+    m.phiS = np.zeros((1, 2))
+    m.phiF = np.zeros((1, 2))
+    m.stratK = np.ones((1, 2))
+    m.tmp = _StubVec([4.0])
+    m.tmpL = _StubVec([0.0])
+    m.dm = _StubDM()
+    m.deposeStrat()
+    assert np.isclose(m.stratH[0, 1], 4.0)
+    assert np.isclose(m.stratHf[0, 1], 4.0 * 0.25), (
+        "Fine deposit must equal depo * global eroded fine fraction."
+    )
+    assert np.isclose(m.phiF[0, 1], 0.63) and np.isclose(m.phiS[0, 1], 0.49)
+
+    # ---- Compaction: one mixed layer buried 2 km ----
+    m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
+    m.stratStep = 0
+    m.stratLith = True
+    m.memclear = False
+    m.bedrockLay = 0
+    m.phi0c, m.z0c = 0.49, 3700.0
+    m.phi0f, m.z0f = 0.63, 1960.0
+    Hc0, Hf0 = 6.0, 4.0
+    m.stratH = np.array([[Hc0 + Hf0]])
+    m.stratHf = np.array([[Hf0]])
+    m.phiS = np.array([[0.49]])
+    m.phiF = np.array([[0.63]])
+    depth = np.array([[-2000.0]])
+    newH = m._depthPorosity(depth)
+
+    phiS_new = 0.49 * np.exp(-2000.0 / 3700.0)
+    phiF_new = 0.63 * np.exp(-2000.0 / 1960.0)
+    # Per-fraction solid is conserved through compaction.
+    Hc_new = newH[0, 0] - m.stratHf[0, 0]
+    Hf_new = m.stratHf[0, 0]
+    assert np.isclose(Hc_new * (1 - phiS_new), Hc0 * (1 - 0.49), rtol=1e-9), (
+        "Coarse solid must be conserved through compaction."
+    )
+    assert np.isclose(Hf_new * (1 - phiF_new), Hf0 * (1 - 0.63), rtol=1e-9), (
+        "Fine solid must be conserved through compaction."
+    )
+    assert newH[0, 0] < Hc0 + Hf0, "Compaction must reduce total thickness."
+    # Fines lose proportionally more bulk than coarse at the same depth.
+    assert (Hf_new / Hf0) < (Hc_new / Hc0), (
+        "Fines must compact more than coarse for these curves."
+    )
+
+
 # ---------------------------------------------------------------------------
 # TEST 2c - channel-evap hook reduces FA (DESIGN_EVAPORATION.md §4 T1)
 # ---------------------------------------------------------------------------
@@ -1716,6 +1801,7 @@ def test_stratigraphy_deposition_and_compaction():
     s.z0s       = 100.0    # e-folding compaction depth (m)
     s.bedrockLay = 0       # no infinite-bedrock sentinel layer
     s.memclear  = False
+    s.stratLith = False    # single-fraction path (dual-lithology disabled)
 
     s.stratH = np.full((5, 3), 50.0, dtype=np.float64)
     s.phiS   = np.full((5, 3),  0.5, dtype=np.float64)
@@ -1847,6 +1933,7 @@ def test_stratigraphy_deposition_and_compaction():
     s2.z0s       = 100.0
     s2.bedrockLay = 1      # layer 0 is bedrock
     s2.memclear  = False
+    s2.stratLith = False   # single-fraction path (dual-lithology disabled)
 
     # Layer 0 holds the BEDROCK_SENTINEL thickness (1e6) — never compact it.
     s2.stratH = np.array([[1.0e6, 50.0, 50.0]] * 5, dtype=np.float64)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -237,6 +237,128 @@ def test_evap_parser_opt_in():
 
 
 # ---------------------------------------------------------------------------
+# TEST 2b - dual-lithology opt-in flag (DESIGN_DUAL_LITHOLOGY.md Phase 0)
+# ---------------------------------------------------------------------------
+
+
+def _strata_parser(stratNb):
+    """
+    Bare parser primed for `_extraStrata`: it reads `self.input`,
+    `self.phi0s`/`self.z0s` (set by `_readCompaction` upstream), and
+    `self.stratNb` (set by `_readTime` upstream). See `_bare_parser`.
+    """
+    parser = inputparser.ReadYaml.__new__(inputparser.ReadYaml)
+    parser.input = {}
+    parser.phi0s = 0.49
+    parser.z0s = 3700.0
+    parser.stratNb = stratNb
+    return parser
+
+
+def test_dual_lithology_opt_in():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 0 — dual lithology is an
+    opt-in parsed in `_extraStrata` (continuation of `_readCompaction`).
+
+    Silent failure prevented: a refactor dropping the `_extraStrata` call
+    from `_readCompaction`, or flipping the default, would silently change
+    the sediment model for every existing input file.
+
+    Invariants:
+      1. No `strata` block  → stratLith False; coarse curve == compaction
+         curve (the dual-off path must stay bitwise-identical).
+      2. `strata: dual: True` with stratigraphy on → stratLith True and the
+         per-lithology parameters are parsed.
+      3. `strata: dual: True` with stratigraphy OFF (stratNb == 0) → flag
+         forced back to False (dual requires stratigraphy).
+    """
+    # ---- Case 1: no strata block → single-fraction, defaults mirror compaction
+    parser = _strata_parser(stratNb=5)
+    parser._extraStrata()
+    assert parser.stratLith is False
+    assert parser.phi0c == parser.phi0s and parser.z0c == parser.z0s, (
+        "Dual-off coarse porosity curve must default to the single-fraction "
+        "compaction curve so behaviour is unchanged."
+    )
+
+    # ---- Case 2: dual on with stratigraphy enabled → parsed
+    parser = _strata_parser(stratNb=5)
+    parser.input = {
+        "strata": {
+            "dual": True,
+            "coarse": {"phi0": 0.45, "z0": 3000.0},
+            "fine": {"phi0": 0.65, "z0": 1500.0},
+            "bedrock_coarse_frac": 0.7,
+            "fine_efficiency": 0.3,
+            "pitInletBias": {"coarse": 0.8, "fine": 0.1},
+            "Dc": 0.01,
+            "Df": 0.05,
+        }
+    }
+    parser._extraStrata()
+    assert parser.stratLith is True
+    assert parser.phi0c == 0.45 and parser.z0c == 3000.0
+    assert parser.phi0f == 0.65 and parser.z0f == 1500.0
+    assert parser.bedrock_coarse_frac == 0.7
+    assert parser.fine_efficiency == 0.3
+    assert parser.pit_inlet_bias_coarse == 0.8
+    assert parser.pit_inlet_bias_fine == 0.1
+    assert parser.Dc == 0.01 and parser.Df == 0.05
+
+    # ---- Case 3: dual requested but stratigraphy off → forced False
+    parser = _strata_parser(stratNb=0)
+    parser.input = {"strata": {"dual": True}}
+    parser._extraStrata()
+    assert parser.stratLith is False, (
+        "Dual lithology must require stratigraphy (stratNb > 0); with strat "
+        "disabled the flag has to fall back to single-fraction."
+    )
+
+
+def test_dual_lithology_layer_allocation():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 1 — the fine-fraction layer
+    fields (stratHf, phiF) are allocated by readStratLayers only when
+    dual lithology is enabled, and stay None otherwise.
+
+    Silent failure prevented: allocating the fields unconditionally would
+    change the single-fraction memory footprint and (via _outputStrat)
+    write extra HDF5 datasets into every existing single-fraction run.
+
+    Exercises the no-file branch of readStratLayers directly via __new__,
+    which only needs lpoints/stratNb/phi0s/stratLith/memclear/strataFile.
+    """
+    from gospl.sed import stratplex
+
+    def _strata_mesh(stratLith):
+        m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
+        m.strataFile = None
+        m.lpoints = 8
+        m.stratNb = 3
+        m.phi0s = 0.49
+        m.memclear = False
+        m.stratLith = stratLith
+        m.stratHf = None
+        m.phiF = None
+        return m
+
+    # Single-fraction: fine fields stay None.
+    m = _strata_mesh(stratLith=False)
+    m.readStratLayers()
+    assert m.stratHf is None and m.phiF is None, (
+        "Single-fraction run must not allocate stratHf/phiF."
+    )
+
+    # Dual: fine fields allocated with the same shape as stratH, all-coarse.
+    m = _strata_mesh(stratLith=True)
+    m.readStratLayers()
+    assert m.stratHf is not None and m.phiF is not None
+    assert m.stratHf.shape == m.stratH.shape == (m.lpoints, m.stratNb)
+    assert m.phiF.shape == (m.lpoints, m.stratNb)
+    assert (m.stratHf == 0.0).all(), "Initial dual column should be all-coarse."
+
+
+# ---------------------------------------------------------------------------
 # TEST 2c - channel-evap hook reduces FA (DESIGN_EVAPORATION.md §4 T1)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -330,12 +330,16 @@ def test_dual_lithology_layer_allocation():
     """
     from gospl.sed import stratplex
 
+    from gospl.tools.constants import BEDROCK_SENTINEL
+
     def _strata_mesh(stratLith):
         m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
         m.strataFile = None
         m.lpoints = 8
         m.stratNb = 3
         m.phi0s = 0.49
+        m.phi0f = 0.63
+        m.bedrock_coarse_frac = 0.5
         m.memclear = False
         m.stratLith = stratLith
         m.stratHf = None
@@ -349,13 +353,118 @@ def test_dual_lithology_layer_allocation():
         "Single-fraction run must not allocate stratHf/phiF."
     )
 
-    # Dual: fine fields allocated with the same shape as stratH, all-coarse.
+    # Dual: fine fields allocated with stratH's shape. The bedrock sentinel
+    # layer (layer 0) carries the bedrock fine fraction; layers above are 0.
     m = _strata_mesh(stratLith=True)
     m.readStratLayers()
     assert m.stratHf is not None and m.phiF is not None
     assert m.stratHf.shape == m.stratH.shape == (m.lpoints, m.stratNb)
     assert m.phiF.shape == (m.lpoints, m.stratNb)
-    assert (m.stratHf == 0.0).all(), "Initial dual column should be all-coarse."
+    assert np.allclose(m.stratHf[:, 0], BEDROCK_SENTINEL * (1.0 - 0.5)), (
+        "Bedrock-sentinel layer must carry the (1 - bedrock_coarse_frac) fine split."
+    )
+    assert (m.stratHf[:, 1:] == 0.0).all(), "Layers above bedrock start coarse-empty."
+
+
+def test_dual_lithology_erosion_split():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 2 — erodeStrat splits the
+    eroded solid into thCoarse/thFine by the consumed layers' composition,
+    and stays mass-consistent. K-blend / composition helpers also tested.
+
+    Builds a tiny single-node column by hand and drives erodeStrat through
+    a stubbed PETSc boundary (tmpL/globalToLocal), so the split arithmetic
+    is exercised without a full model.
+
+    Invariants:
+      1. All-coarse column -> thFine == 0 and thCoarse matches what the
+         single-fraction branch would produce (parity).
+      2. Mixed column -> the deposited (uncompacted) split reconstructs the
+         eroded solid: thCoarse*(1-phi0c) + thFine*(1-phi0f) == solid removed.
+      3. _surfaceComposition / _surfaceLithoK reflect the exposed layer and
+         the fine_k_factor; both are neutral (1.0) when dual is off.
+    """
+    from gospl.sed import stratplex
+
+    class _StubVec:
+        def __init__(self, arr):
+            self._a = arr
+        def getArray(self):
+            return self._a
+        def setArray(self, a):
+            self._a = np.asarray(a, dtype=np.float64)
+
+    class _StubDM:
+        def globalToLocal(self, g, l):
+            l.setArray(g.getArray().copy())
+
+    def _mesh(stratLith, ero, stratH, stratHf=None, phiS=None, phiF=None):
+        m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
+        lp, nb = stratH.shape
+        m.lpoints, m.stratNb, m.stratStep = lp, nb, nb - 1
+        m.dt = 1.0
+        m.memclear = False
+        m.phi0s = m.phi0c = 0.49
+        m.phi0f = 0.63
+        m.bedrock_coarse_frac = 0.5
+        m.fine_k_factor = 1.0
+        m.stratLith = stratLith
+        m.stratH = stratH.astype(np.float64).copy()
+        m.phiS = (phiS if phiS is not None else np.full_like(stratH, 0.49)).copy()
+        m.stratK = np.ones_like(m.stratH)
+        m.stratHf = stratHf.copy() if stratHf is not None else None
+        m.phiF = phiF.copy() if phiF is not None else None
+        # PETSc boundary stub: tmp carries -ero (erosion is negative).
+        m.tmp = _StubVec(np.array(ero, dtype=np.float64))
+        m.tmpL = _StubVec(np.zeros(lp))
+        m.dm = _StubDM()
+        return m
+
+    # ---- Case 1: all-coarse parity (single vs dual must agree on thCoarse)
+    stratH = np.array([[2.0, 3.0]])          # two layers, total 5 m
+    single = _mesh(False, ero=[-4.0], stratH=stratH)
+    single.erodeStrat()
+    dual = _mesh(
+        True, ero=[-4.0], stratH=stratH,
+        stratHf=np.zeros_like(stratH), phiF=np.full_like(stratH, 0.63),
+    )
+    dual.erodeStrat()
+    assert np.allclose(dual.thFine, 0.0), "All-coarse column must erode no fine."
+    assert np.allclose(dual.thCoarse, single.thCoarse), (
+        "All-coarse dual erosion must match the single-fraction thCoarse."
+    )
+
+    # ---- Case 2: mixed column -> per-fraction solid reconstruction
+    stratH = np.array([[2.0, 3.0]])
+    stratHf = np.array([[1.0, 1.2]])         # fine bulk per layer
+    phiS = np.full_like(stratH, 0.49)
+    phiF = np.full_like(stratH, 0.63)
+    dual = _mesh(True, ero=[-4.0], stratH=stratH, stratHf=stratHf,
+                 phiS=phiS, phiF=phiF)
+    dual.erodeStrat()
+    # Solid removed by erosion of 4 m: fully erode top layer (3 m) + 1 m of
+    # the lower (well-mixed) layer.
+    # top layer (idx1): coarse (3-1.2)*(1-.49) + fine 1.2*(1-.63)
+    # lower (idx0): remove 1 m of 2 m -> half: coarse (2-1)/2*(1-.49)*1 ... compute generically:
+    coarse_solid = (3 - 1.2) * (1 - 0.49) + ((2 - 1.0) * 0.5) * (1 - 0.49)
+    fine_solid = 1.2 * (1 - 0.63) + (1.0 * 0.5) * (1 - 0.63)
+    got = dual.thCoarse[0] * (1 - dual.phi0c) + dual.thFine[0] * (1 - dual.phi0f)
+    assert np.isclose(got, coarse_solid + fine_solid, rtol=1e-9), (
+        f"Per-fraction solid reconstruction failed: got {got}, "
+        f"expected {coarse_solid + fine_solid}"
+    )
+    assert dual.thFine[0] > 0 and dual.thCoarse[0] > 0
+
+    # ---- Case 3: composition + K-blend helpers
+    m = _mesh(True, ero=[0.0], stratH=np.array([[2.0, 2.0]]),
+              stratHf=np.array([[0.0, 0.5]]), phiF=np.full((1, 2), 0.63))
+    fc = m._surfaceComposition()
+    assert np.isclose(fc[0], 1.0 - 0.5 / 2.0), "Surface coarse fraction wrong."
+    m.fine_k_factor = 2.0
+    litK = m._surfaceLithoK()
+    assert np.isclose(litK[0], fc[0] + (1 - fc[0]) * 2.0)
+    m.stratLith = False
+    assert np.allclose(m._surfaceLithoK(), 1.0), "K-blend must be neutral when off."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Dual-lithology (coarse/fine) sediment — co-transport increment

First of two PRs adding an **opt-in dual-lithology** sediment capability (active only when stratigraphy is on). **Default off ⇒ single-fraction behaviour is byte-identical** — every dual path is gated on `self.stratLith`; full regression suite green (17 passed, 1 skipped).

Design: `docs/DESIGN_DUAL_LITHOLOGY.md`.

### What's included (Phases 0–2, 4–5)
- **Phase 0** — `inputparser._extraStrata` parses the `strata:` block (opt-in `dual` flag, per-lithology porosity curves, `fine_k_factor`, `bedrock_coarse_frac`, `fine_efficiency`, per-fraction `pitInletBias`, `fine_diff_factor`). Forced off when stratigraphy is disabled.
- **Phase 1** — fine-fraction state (`stratHf` bulk thickness, `phiF`) allocated in `readStratLayers`; written in `_outputStrat` and restored on restart (gated, so single-fraction HDF5 outputs are unchanged).
- **Phase 2** — `_surfaceComposition()` shared hook; composition-weighted erodibility blend folded into all three SPL flavours; `erodeStrat` splits eroded solid into `thCoarse`/`thFine` by consumed-layer composition (bedrock sentinel inflated proportionally to layer-0 fine ratio).
- **Phase 4** — per-fraction deposition (`deposeStrat`) and per-fraction compaction (`_depthPorosityDual`, each fraction on its own porosity-depth curve; the headline physics).
- **Phase 5** — `stratalRecord` advects the fine pile via a second `strataonesed` call.

### Co-transport behaviour
Composition is tracked through erosion → deposition → compaction → advection; fines compact on their own curve. Sediment is **routed with coarse**: a deposit's fine fraction is the step's *global* eroded composition — a documented placeholder that Phase 3 (separate transport, next PR) replaces with spatially-resolved routed fine.

### Tests
5 dual-lithology unit tests: parser opt-in, state allocation, erosion split (parity + per-fraction solid reconstruction), deposit/compaction (solid conservation + differential compaction), fine-pile advection round-trip.

### Not in this PR (Phase 3, follow-up)
Separate transport: `vSed → vSedC/vSedF` split, per-fraction lake deposition (coarse delta / fine depocenter), per-fraction marine `Gmar`.
