### PR TITLE
Dual-lithology: separate transport (Phase 3) + diffusivity (Phase 7) [stacked on #415]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ results/
 # Regenerated goSPL test outputs (created when tests/fixtures/{minimal,incising}.yml runs)
 tests/fixtures/minimal/
 tests/fixtures/incising/
+tests/fixtures/minimal_strat/
+tests/fixtures/minimal_dual/
+tests/fixtures/minimal_dual_coarse/
 *.so
 .eggs
 MANIFEST

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ NOT optional parsers. Each sets attributes required by other modules. Never dele
 - `_extraDomain` (inputparser.py:189) → `seaDepo`, `overlap`, `dataFile`, `nodep`, `strataFile`; calls `_extraDomain2`.
 - `_extraDomain2` (:229) → `advscheme`, `radius`, `gravity`.
 - `_extraHillslope` (:475) → `nlK`, `clinSlp`, `tsStep`, `Gmar`, `offshore`, `nl_pit_volume/depth/K/inlet_bias`.
-- `_extraStrata` (called from `_readCompaction`) → `stratLith` (dual-lithology master opt-in), `phi0c/z0c` (coarse porosity curve, defaults to compaction `phi0s/z0s`), `phi0f/z0f` (fine), `bedrock_coarse_frac`, `fine_efficiency`, `pit_inlet_bias_coarse/fine`, `Dc/Df`. All inert while `stratLith` is False; forced False if `stratNb == 0`. See `docs/DESIGN_DUAL_LITHOLOGY.md`.
+- `_extraStrata` (called from `_readCompaction`) → `stratLith` (dual-lithology master opt-in), `phi0c/z0c` (coarse porosity curve, defaults to compaction `phi0s/z0s`), `phi0f/z0f` (fine), `fine_k_factor` (fine erodibility multiplier), `bedrock_coarse_frac`, `fine_efficiency`, `pit_inlet_bias_coarse/fine`, `fine_diff_factor` (fine diffusivity multiplier). All inert while `stratLith` is False; forced False if `stratNb == 0`. See `docs/DESIGN_DUAL_LITHOLOGY.md`.
 - `_extraFlex` (:1430) → `nu`, `flex_res_deg`, `flex_bcN/S/E/W`.
 - `_extraOrography` (:1517) → `oro_cw`, `oro_conv_time`, `oro_fall_time`, `oro_precip_*`, `rainfall_frequency`.
 - `_extraIce` (:1621) → `iceT`, `elaH`, `iceH` interpolators.

--- a/docs/DESIGN_DUAL_LITHOLOGY.md
+++ b/docs/DESIGN_DUAL_LITHOLOGY.md
@@ -168,8 +168,12 @@ effective diffusivity in a single solve**:
 
 - `Cd_eff = Cd_base * (fc + ff*fine_diff_factor)`, with `fc/ff` from
   `_surfaceComposition()` and `Cd_base ∈ {Cda, Cdm, nlK}` (the cell's existing
-  land/marine/non-linear coefficient). The diffused flux carries the **donor
-  cell's composition** into `erodeStrat`/`deposeStrat`.
+  land/marine/non-linear coefficient). Implemented via `_surfaceLithoD()`
+  applied in `_hillSlope` (real-hillslope branch), `_hillSlopeNL`, and
+  `soilSPL.diffuseSoil` (the soil-coupled flavour). The marine/lake fresh-
+  deposit smoothing (`_diffuseImplicit`) is intentionally NOT weighted — the
+  subaqueous fines-distal effect is already handled by the 3b/3c depth-biased
+  composition, so weighting it again would double-count.
 - **Drop-in** to the existing solvers — the FV scheme already supports node-
   varying diffusivity (the nonlinear hillslope varies D by slope via
   `Dlimit`/`dexp`); composition is just another multiplicative factor. **No new
@@ -217,8 +221,21 @@ path, with `pitInletBias` per fraction (coarse high, fine ~0). New work:
 2. **Per-fraction deposit shape** — coarse → `_diffuseLargePit`, fine →
    `_bottomUpDelta`.
 3. **Fine-enriched overspill** — the excess `eV` overspilling a filled lake
-   (`sedplex.py:118-126`) carries composition; coarse is largely trapped, so
-   overspill is fine-enriched (and may bypass downstream).
+   should be fine-enriched (coarse trapped proximally). **NOT IMPLEMENTED — known
+   limitation.** A conservative implementation requires threading a parallel
+   fine volume through the iterative `_moveDownstream` cascade (coarse-settles-
+   first retention + routing the fine overspill + accumulating the post-cascade
+   fine into `vSedFLocal` for the marine handoff). An attempt was made and
+   reverted: the `vSedLocal` accumulation semantics (initial routed flux on the
+   *unfilled* topology + masked residuals across cascade iterations + pit-volume
+   bookkeeping) are subtle, and a mismatched fine mirror leaked fine (~10× drop
+   in deposited fine) — and crucially the total-cumED conservation test does
+   **not** catch a fine-only leak. Until the cascade's flux semantics are fully
+   pinned down (ideally with a fine-specific conservation test), the in-pit
+   composition uses the routed arriving fraction (3b depth-bias), not the
+   coarse-settles-first retained fraction; overspill carries the routed
+   composition. This is second-order vs the depocenter/distal bias already
+   shipped (3b/3c).
 4. **Fresh porosity** — lacustrine coarse → `phi0c`, fine → `phi0f` (feeds the
    per-fraction compaction).
 5. **Per-fraction mass conservation across the cascade** — the spillover cascade

--- a/gospl/eroder/soilSPL.py
+++ b/gospl/eroder/soilSPL.py
@@ -466,6 +466,11 @@ class soilSPL(object):
         # Get diffusion soil coefficient
         self.Cd = np.full(self.lpoints, self.Cda, dtype=np.float64)
         self.Cd[self.seaID] = self.Cdm
+        # Dual-lithology (Phase 7): scale soil diffusivity by the surface
+        # composition so fine-rich soil diffuses faster (neutral when single-
+        # fraction / no contrast).
+        if self.stratLith:
+            self.Cd = self.Cd * self._surfaceLithoD()
 
         # Remove the soil thickness from the elevation
         self.hLocal.copy(result=self.hl)

--- a/gospl/mesher/unstructuredmesh.py
+++ b/gospl/mesher/unstructuredmesh.py
@@ -820,6 +820,8 @@ class UnstMesh(object):
         self.cumEDLocal.destroy()
         self.vSed.destroy()
         self.vSedLocal.destroy()
+        self.vSedF.destroy()
+        self.vSedFLocal.destroy()
         self.areaGlobal.destroy()
         self.bG.destroy()
         self.bL.destroy()

--- a/gospl/sed/hillslope.py
+++ b/gospl/sed/hillslope.py
@@ -82,6 +82,11 @@ class hillSLP(object):
         else:
             Cd = np.full(self.lpoints, self.Cda, dtype=np.float64)
             Cd[self.seaID] = self.Cdm
+            # Dual-lithology (Phase 7): scale the diffusivity by the surface
+            # composition so fines diffuse faster (1.0 everywhere when single-
+            # fraction / no contrast, so behaviour is unchanged).
+            if self.stratLith:
+                Cd = Cd * self._surfaceLithoD()
         diffCoeffs = sethillslopecoeff(self.lpoints, Cd * self.dt)
         if self.flatModel:
             diffCoeffs[self.idBorders, 1:] = 0.0
@@ -208,6 +213,11 @@ class hillSLP(object):
         self.hGlobal.copy(result=self.hOld)
         self.Cd_nl = np.full(self.lpoints, self.Cda, dtype=np.float64)
         self.Cd_nl[self.seaID] = self.Cdm
+        # Dual-lithology (Phase 7): scale the non-linear diffusivity by the
+        # surface composition so fines diffuse faster (neutral when single-
+        # fraction / no contrast).
+        if self.stratLith:
+            self.Cd_nl = self.Cd_nl * self._surfaceLithoD()
         self.hOldArray = self.hLocal.getArray().copy()
 
         if self._snes_hill is None:

--- a/gospl/sed/seaplex.py
+++ b/gospl/sed/seaplex.py
@@ -486,6 +486,55 @@ class SEAMesh(object):
 
         return vdep
 
+    def _marineFineFraction(self, hl, sedFlux):
+        """
+        Dual-lithology (3c): set the per-node fine fraction of the marine
+        deposit so fine concentrates in deep / distal water and coarse stays
+        proximal (near the coast), conserving the marine fine volume.
+
+        Composition only — the marine deposit geometry (already in ``self.tmp``
+        after ``_distOcean``/``_depMarineSystem``/``_diffuseOcean``) is NOT
+        modified, so elevations/flow are untouched. This is the subaqueous
+        analogue of ``sedplex._pitFineFraction``: the lower-Gmar "fines deposit
+        less readily / travel farther" behaviour is expressed as fine biased
+        toward the deeper deposits rather than re-routed.
+
+        Mechanism:
+          - Domain marine fine fraction ``ff_mar = Σ(fineFrac·sedFlux) /
+            Σ(sedFlux)`` — flux-weighted composition of sediment entering the
+            sea (``sedFlux`` is the marine input volume, zero outside sinks).
+          - Water depth ``d = max(sealevel − hl, 0)`` is the distal/deep proxy.
+          - Fine fraction biased ∝ d, renormalised to the deposit-weighted mean
+            depth, so ``Σ(mdep·larea·ffrac) == ff_mar·Σ(mdep·larea)``.
+
+        :arg hl: pre-deposition local elevation
+        :arg sedFlux: marine input sediment volume per node (m^3)
+        """
+        self.dm.globalToLocal(self.tmp, self.tmpL)
+        mdep = self.tmpL.getArray().copy()
+        owned = self.inIDs == 1
+
+        # Flux-weighted fine fraction of sediment entering the marine domain.
+        fineNum = float(np.sum((self.fineFrac * sedFlux)[owned]))
+        den = float(np.sum(sedFlux[owned]))
+        fineNum = MPI.COMM_WORLD.allreduce(fineNum, op=MPI.SUM)
+        den = MPI.COMM_WORLD.allreduce(den, op=MPI.SUM)
+        ff_mar = fineNum / den if den > 0.0 else 0.0
+
+        # Deposit-weighted mean water depth.
+        depth = np.maximum(self.sealevel - hl, 0.0)
+        mvol = mdep * self.larea
+        dw = MPI.COMM_WORLD.allreduce(float(np.sum(mvol[owned])), op=MPI.SUM)
+        dwd = MPI.COMM_WORLD.allreduce(float(np.sum((mvol * depth)[owned])), op=MPI.SUM)
+        depthbar = dwd / dw if dw > 0.0 else 0.0
+
+        if depthbar > 0.0:
+            ffrac = np.clip(ff_mar * depth / max(depthbar, 1.0e-30), 0.0, 1.0)
+            marine = mdep > 0.0
+            self.depoFineFrac[marine] = ffrac[marine]
+
+        return
+
     def seaChange(self):
         """
         This function is the main entry point to perform marine river-induced deposition. It calls the private functions:
@@ -557,6 +606,8 @@ class SEAMesh(object):
 
         # Update stratigraphic layer parameters
         if self.stratNb > 0:
+            if self.stratLith:
+                self._marineFineFraction(hl, sedFlux)
             self.deposeStrat()
 
         if MPIrank == 0 and self.verbose:

--- a/gospl/sed/sedplex.py
+++ b/gospl/sed/sedplex.py
@@ -35,6 +35,16 @@ class SEDMesh(object):
         self.vSed = self.hGlobal.duplicate()
         self.vSedLocal = self.hLocal.duplicate()
 
+        # Dual-lithology fine sediment flux (m3/yr). vSed carries the TOTAL
+        # (coarse+fine) sediment; vSedF carries the fine sub-flux, both routed
+        # by the same upstream-integration operator. fineFrac is the per-node
+        # fine fraction of the routed flux (= arriving-sediment composition at
+        # sinks), used by deposeStrat. Allocated unconditionally (negligible)
+        # and registered in destroy_DMPlex; only populated when stratLith.
+        self.vSedF = self.hGlobal.duplicate()
+        self.vSedFLocal = self.hLocal.duplicate()
+        self.fineFrac = np.zeros(self.lpoints, dtype=np.float64)
+
         # Get the maximum number of neighbours on the mesh
         maxnb = np.zeros(1, dtype=np.int64)
         maxnb[0] = setmaxnb(self.lpoints)
@@ -54,8 +64,13 @@ class SEDMesh(object):
         # Stratigraphic layers exist
         if self.stratNb > 0:
             # thCoarse is already an erosion-positive rate (m/yr) from
-            # stratplex.erodeStrat; use as-is.
-            self.tmpL.setArray(self.thCoarse)
+            # stratplex.erodeStrat; use as-is. In dual-lithology mode the
+            # transported sediment is the TOTAL (coarse + fine) so the
+            # deposition machinery handles all eroded volume.
+            if self.stratLith:
+                self.tmpL.setArray(self.thCoarse + self.thFine)
+            else:
+                self.tmpL.setArray(self.thCoarse)
             self.dm.localToGlobal(self.tmpL, self.tmp)
         else:
             # Eb is in the thickness-rate convention (positive deposition,
@@ -68,6 +83,25 @@ class SEDMesh(object):
         # Get the volume of sediment transported in m3/yr
         self.tmp.pointwiseMult(self.tmp, self.areaGlobal)
         self._solve_KSP(False, self.fMati, self.tmp, self.vSed)
+
+        # Dual lithology: route the fine sub-flux through the SAME operator
+        # (linear, so this is exact), then snapshot the per-node fine fraction
+        # of the routed (upstream-integrated) flux — i.e. the composition of
+        # sediment arriving at each node. Done before fMati is destroyed.
+        if self.stratNb > 0 and self.stratLith:
+            self.tmpL.setArray(self.thFine)
+            self.dm.localToGlobal(self.tmpL, self.tmp)
+            self.tmp.pointwiseMult(self.tmp, self.areaGlobal)
+            self._solve_KSP(False, self.fMati, self.tmp, self.vSedF)
+            self.dm.globalToLocal(self.vSed, self.vSedLocal)
+            self.dm.globalToLocal(self.vSedF, self.vSedFLocal)
+            vtot = self.vSedLocal.getArray()
+            vfin = self.vSedFLocal.getArray()
+            self.fineFrac = np.divide(
+                vfin, vtot, out=np.zeros_like(vtot), where=vtot > 0.0
+            )
+            np.clip(self.fineFrac, 0.0, 1.0, out=self.fineFrac)
+
         self.fMati.destroy()
 
         # Update local vector

--- a/gospl/sed/sedplex.py
+++ b/gospl/sed/sedplex.py
@@ -44,6 +44,14 @@ class SEDMesh(object):
         self.vSedF = self.hGlobal.duplicate()
         self.vSedFLocal = self.hLocal.duplicate()
         self.fineFrac = np.zeros(self.lpoints, dtype=np.float64)
+        # depoFineFrac is the per-node fine fraction actually used by
+        # deposeStrat. It starts each step as the routed arriving composition
+        # (fineFrac) and is overridden inside pits by _pitFineFraction (3b:
+        # fine biased to the depocenter, coarse to the margins/inlet).
+        # _totFlux snapshots the pre-cascade total routed flux (vSedLocal is
+        # later mutated by the pit cascade) so per-pit fine fractions stay valid.
+        self.depoFineFrac = np.zeros(self.lpoints, dtype=np.float64)
+        self._totFlux = np.zeros(self.lpoints, dtype=np.float64)
 
         # Get the maximum number of neighbours on the mesh
         maxnb = np.zeros(1, dtype=np.int64)
@@ -101,6 +109,11 @@ class SEDMesh(object):
                 vfin, vtot, out=np.zeros_like(vtot), where=vtot > 0.0
             )
             np.clip(self.fineFrac, 0.0, 1.0, out=self.fineFrac)
+            # Snapshot the clean pre-cascade total flux and seed the deposit
+            # composition with the arriving (routed) fine fraction; _updateSinks
+            # refines it inside pits (3b).
+            self._totFlux = vtot.copy()
+            self.depoFineFrac = self.fineFrac.copy()
 
         self.fMati.destroy()
 
@@ -597,6 +610,73 @@ class SEDMesh(object):
 
         return delta_smooth
 
+    def _pitFineFraction(self, hl, delta):
+        """
+        Dual-lithology (3b): set the per-node fine fraction of the continental
+        pit/lake deposit so fine settles toward the depocenter and coarse
+        builds the inlet/margins, while conserving each pit's incoming fine
+        volume.
+
+        Composition only — the deposit geometry ``delta`` is NOT modified, so
+        model dynamics (elevations, flow) are untouched; the worst case of a
+        bug here is a wrong recorded composition, caught by the per-fraction
+        invariant tests.
+
+        Mechanism:
+          - Per-pit incoming fine fraction ``ff_pit = Σ(fineFrac·totFlux) /
+            Σ(totFlux)`` over the pit's nodes — the routed-flux composition of
+            sediment entering the pit (``_totFlux`` is the clean pre-cascade
+            snapshot; ``vSedLocal`` is mutated by the cascade).
+          - Bathymetric depth ``d = max(lFill − hl, 0)`` is the depocenter
+            proxy (deep at the centre, shallow at the rim/inlet — independent
+            of where the deposit piled).
+          - Fine fraction is biased ∝ d and renormalised to the deposit-weighted
+            mean depth, so ``Σ(delta·larea·ffrac) == ff_pit·Σ(delta·larea) ==``
+            the fine volume that entered the pit.
+
+        :arg hl: pre-deposition local elevation
+        :arg delta: per-node continental deposit thickness (local)
+        """
+        num_pits = len(self.pitParams)
+        in_pit = self.pitIDs >= 0
+        owned = (self.inIDs == 1) & in_pit
+
+        # ---- per-pit incoming fine fraction (flux-weighted) ----
+        fineNum = np.zeros(num_pits, dtype=np.float64)
+        fluxDen = np.zeros(num_pits, dtype=np.float64)
+        # ---- deposit-weighted mean bathymetric depth per pit ----
+        depth = np.maximum(self.lFill - hl, 0.0)
+        dw = np.zeros(num_pits, dtype=np.float64)   # Σ delta*larea
+        dwd = np.zeros(num_pits, dtype=np.float64)  # Σ delta*larea*depth
+        if owned.any():
+            ids = self.pitIDs[owned]
+            grp = npi.group_by(ids)
+            up = grp.unique
+            fineNum[up] = grp.sum((self.fineFrac * self._totFlux)[owned])[1]
+            fluxDen[up] = grp.sum(self._totFlux[owned])[1]
+            dl = (delta * self.larea)[owned]
+            dw[up] = grp.sum(dl)[1]
+            dwd[up] = grp.sum(dl * depth[owned])[1]
+        MPI.COMM_WORLD.Allreduce(MPI.IN_PLACE, fineNum, op=MPI.SUM)
+        MPI.COMM_WORLD.Allreduce(MPI.IN_PLACE, fluxDen, op=MPI.SUM)
+        MPI.COMM_WORLD.Allreduce(MPI.IN_PLACE, dw, op=MPI.SUM)
+        MPI.COMM_WORLD.Allreduce(MPI.IN_PLACE, dwd, op=MPI.SUM)
+
+        ff_pit = np.divide(fineNum, fluxDen, out=np.zeros(num_pits), where=fluxDen > 0)
+        depthbar = np.divide(dwd, dw, out=np.zeros(num_pits), where=dw > 0)
+
+        # ---- per-node biased fine fraction (depocenter-weighted) ----
+        pit_safe = np.where(in_pit, self.pitIDs, 0)
+        ffp = ff_pit[pit_safe]
+        db = depthbar[pit_safe]
+        ffrac = np.where(
+            in_pit & (db > 0.0), ffp * depth / np.maximum(db, 1.0e-30), 0.0
+        )
+        np.clip(ffrac, 0.0, 1.0, out=ffrac)
+        self.depoFineFrac[in_pit] = ffrac[in_pit]
+
+        return
+
     def _updateSinks(self, hl):
         """
         Update depression elevations based on incoming sediment volumes.
@@ -639,6 +719,12 @@ class SEDMesh(object):
         if diffuse_path.any():
             delta_diff = self._diffuseLargePit(hl, depo, diffuse_path)
             delta = delta + delta_diff
+
+        # Dual lithology (3b): bias the deposit composition within pits — fine
+        # to the depocenter, coarse to the inlet/margins. Geometry (delta) is
+        # unchanged; only self.depoFineFrac (read by deposeStrat) is set.
+        if self.stratLith:
+            self._pitFineFraction(hl, delta)
 
         # Apply deposit
         self.tmpL.setArray(delta)

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -222,6 +222,22 @@ class STRAMesh(object):
         fc = self._surfaceComposition()
         return fc + (1.0 - fc) * self.fine_k_factor
 
+    def _surfaceLithoD(self):
+        """
+        Per-node diffusivity multiplier from the exposed surface composition:
+        ``fc + (1 - fc) * fine_diff_factor``.
+
+        Equals 1.0 everywhere when dual lithology is off (or
+        ``fine_diff_factor == 1``, i.e. no contrast), so it composes
+        multiplicatively with the base hillslope coefficients (``Cda``/``Cdm``)
+        without altering single-fraction behaviour. Fines diffuse faster when
+        ``fine_diff_factor > 1`` (see DESIGN_DUAL_LITHOLOGY.md Section 7).
+        """
+        if not self.stratLith:
+            return np.ones(self.lpoints, dtype=np.float64)
+        fc = self._surfaceComposition()
+        return fc + (1.0 - fc) * self.fine_diff_factor
+
     def deposeStrat(self):
         """
         Add deposition on top of an existing stratigraphic layer. The following variables will be recorded:

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -230,11 +230,12 @@ class STRAMesh(object):
         - porosity of sediment `phiS` in each stratigraphic layer computed at center of each layer.
 
         In dual-lithology mode the deposit is split into a coarse and a fine
-        fraction. The fine fraction is the step's **global eroded composition**
-        (``Σ thFine / Σ (thCoarse + thFine)`` over the domain) — a co-transport
-        placeholder: fines are assumed to travel with coarse so a deposit
-        carries the bulk source composition. Phase 3 (separate transport)
-        replaces this scalar with a spatially-resolved routed fine deposit.
+        fraction using the **per-node fine fraction** ``self.fineFrac`` — the
+        composition of the routed (upstream-integrated) sediment arriving at
+        each node, snapshotted in ``sedplex._getSedFlux``. This is the
+        spatially-resolved replacement for the earlier global-composition
+        placeholder. (3b/3c add differential coarse/fine deposition so the
+        arriving fine fraction itself reflects "fines travel farther".)
         """
 
         self.dm.globalToLocal(self.tmp, self.tmpL)
@@ -243,14 +244,7 @@ class STRAMesh(object):
         self.stratH[:, self.stratStep] += depo
         ids = np.where(depo > 0)[0]
         if self.stratLith:
-            # Area-weighted global eroded fine fraction (collective: every
-            # rank participates, matching the MPI contract).
-            cV = float(np.sum(self.thCoarse * self.larea))
-            fV = float(np.sum(self.thFine * self.larea))
-            cV = MPI.COMM_WORLD.allreduce(cV, op=MPI.SUM)
-            fV = MPI.COMM_WORLD.allreduce(fV, op=MPI.SUM)
-            ff_dep = fV / (cV + fV) if (cV + fV) > 0.0 else 0.0
-            self.stratHf[:, self.stratStep] += depo * ff_dep
+            self.stratHf[:, self.stratStep] += depo * self.fineFrac
             # Fresh deposit carries each lithology's surface porosity.
             self.phiS[ids, self.stratStep] = self.phi0c
             self.phiF[ids, self.stratStep] = self.phi0f

--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -230,12 +230,11 @@ class STRAMesh(object):
         - porosity of sediment `phiS` in each stratigraphic layer computed at center of each layer.
 
         In dual-lithology mode the deposit is split into a coarse and a fine
-        fraction using the **per-node fine fraction** ``self.fineFrac`` — the
-        composition of the routed (upstream-integrated) sediment arriving at
-        each node, snapshotted in ``sedplex._getSedFlux``. This is the
-        spatially-resolved replacement for the earlier global-composition
-        placeholder. (3b/3c add differential coarse/fine deposition so the
-        arriving fine fraction itself reflects "fines travel farther".)
+        fraction using the **per-node deposit fine fraction** ``self.depoFineFrac``.
+        It starts each step as ``self.fineFrac`` (the composition of the routed
+        sediment arriving at each node, from ``sedplex._getSedFlux``) and is
+        refined inside continental depressions by ``_pitFineFraction`` (3b:
+        fine biased to the depocenter, coarse to the inlet/margins).
         """
 
         self.dm.globalToLocal(self.tmp, self.tmpL)
@@ -244,7 +243,7 @@ class STRAMesh(object):
         self.stratH[:, self.stratStep] += depo
         ids = np.where(depo > 0)[0]
         if self.stratLith:
-            self.stratHf[:, self.stratStep] += depo * self.fineFrac
+            self.stratHf[:, self.stratStep] += depo * self.depoFineFrac
             # Fresh deposit carries each lithology's surface porosity.
             self.phiS[ids, self.stratStep] = self.phi0c
             self.phiF[ids, self.stratStep] = self.phi0f

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -1458,8 +1458,10 @@ class ReadYaml(object):
         self.fine_efficiency = 0.5
         self.pit_inlet_bias_coarse = 0.50
         self.pit_inlet_bias_fine = 0.0
-        self.Dc = None
-        self.Df = None
+        # Fine diffusivity relative to coarse: a multiplier on the existing
+        # hillslope coefficients (Cda/Cdm/nlK), NOT an absolute coefficient.
+        # Cd_eff = Cd_base * (fc + ff * fine_diff_factor). 1.0 = no contrast.
+        self.fine_diff_factor = 1.0
 
         # TODO-REFACTOR: complex except, needs manual review (outer-section: sets stratLith=False on missing "strata")
         try:
@@ -1487,8 +1489,9 @@ class ReadYaml(object):
                 )
                 self.pit_inlet_bias_fine = biasDict.get("fine", self.pit_inlet_bias_fine)
 
-            self.Dc = strataDict.get("Dc", None)
-            self.Df = strataDict.get("Df", None)
+            self.fine_diff_factor = strataDict.get(
+                "fine_diff_factor", self.fine_diff_factor
+            )
 
         except KeyError:
             self.stratLith = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,35 @@ def minimal_model():
 
 
 @pytest.fixture
+def minimal_strat_model():
+    """
+    Minimal model with stratigraphy recording ON (single-fraction). Baseline
+    for the dual-lithology all-coarse parity test. See minimal_strat.yml.
+    """
+    return _instantiate("minimal_strat.yml")
+
+
+@pytest.fixture
+def minimal_dual_model():
+    """
+    Minimal model with dual-lithology (coarse/fine) stratigraphy enabled
+    (realistic fine contrast). Exercises the full dual path end-to-end:
+    erodeStrat split, _getSedFlux fine routing, deposeStrat fineFrac,
+    per-fraction compaction, fine-pile advection. See minimal_dual.yml.
+    """
+    return _instantiate("minimal_dual.yml")
+
+
+@pytest.fixture
+def minimal_dual_coarse_model():
+    """
+    Dual lithology enabled but configured all-coarse (bedrock_coarse_frac=1.0,
+    no contrast). Must reproduce minimal_strat_model. See minimal_dual_coarse.yml.
+    """
+    return _instantiate("minimal_dual_coarse.yml")
+
+
+@pytest.fixture
 def incising_model():
     """
     Tilted-plane Model with rain and `nodep: true` so the river-incision

--- a/tests/fixtures/minimal_dual.yml
+++ b/tests/fixtures/minimal_dual.yml
@@ -1,0 +1,42 @@
+name: minimal dual-lithology test
+
+domain:
+    npdata: ['mesh','v','c','z']
+    flowdir: 2
+    bc: '1111'
+    seadepo: True
+    nodep: False
+
+time:
+    start: 0.
+    end: 100
+    tout: 50
+    dt: 10.
+    strat: 50
+
+spl:
+    K: 4.0e-6
+    d: 0.
+    m: 0.5
+    G: 0.
+
+diffusion:
+    hillslopeKa: 0.01
+    hillslopeKm: 0.2
+
+strata:
+    dual: True
+    coarse: {phi0: 0.49, z0: 3700.}
+    fine: {phi0: 0.63, z0: 1960., k_factor: 1.5}
+    bedrock_coarse_frac: 0.6
+    fine_diff_factor: 2.0
+
+sea:
+    position: -100.
+
+climate:
+  - start: 0.
+    uniform: 1
+
+output:
+    dir: 'minimal_dual'

--- a/tests/fixtures/minimal_dual_coarse.yml
+++ b/tests/fixtures/minimal_dual_coarse.yml
@@ -1,0 +1,46 @@
+name: minimal dual-lithology all-coarse parity test
+
+# Dual lithology enabled but configured all-coarse (bedrock_coarse_frac: 1.0,
+# no fine erodibility / diffusivity contrast). With no fine ever produced, the
+# dual code paths must reproduce the single-fraction stratigraphy run
+# (minimal_strat.yml) — this is the parity guard.
+
+domain:
+    npdata: ['mesh','v','c','z']
+    flowdir: 2
+    bc: '1111'
+    seadepo: True
+    nodep: False
+
+time:
+    start: 0.
+    end: 100
+    tout: 50
+    dt: 10.
+    strat: 50
+
+spl:
+    K: 4.0e-6
+    d: 0.
+    m: 0.5
+    G: 0.
+
+diffusion:
+    hillslopeKa: 0.01
+    hillslopeKm: 0.2
+
+strata:
+    dual: True
+    bedrock_coarse_frac: 1.0
+    fine: {k_factor: 1.0}
+    fine_diff_factor: 1.0
+
+sea:
+    position: -100.
+
+climate:
+  - start: 0.
+    uniform: 1
+
+output:
+    dir: 'minimal_dual_coarse'

--- a/tests/fixtures/minimal_strat.yml
+++ b/tests/fixtures/minimal_strat.yml
@@ -1,0 +1,35 @@
+name: minimal strat test
+
+domain:
+    npdata: ['mesh','v','c','z']
+    flowdir: 2
+    bc: '1111'
+    seadepo: True
+    nodep: False
+
+time:
+    start: 0.
+    end: 100
+    tout: 50
+    dt: 10.
+    strat: 50
+
+spl:
+    K: 4.0e-6
+    d: 0.
+    m: 0.5
+    G: 0.
+
+diffusion:
+    hillslopeKa: 0.01
+    hillslopeKm: 0.2
+
+sea:
+    position: -100.
+
+climate:
+  - start: 0.
+    uniform: 1
+
+output:
+    dir: 'minimal_strat'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -287,23 +287,23 @@ def test_dual_lithology_opt_in():
         "strata": {
             "dual": True,
             "coarse": {"phi0": 0.45, "z0": 3000.0},
-            "fine": {"phi0": 0.65, "z0": 1500.0},
+            "fine": {"phi0": 0.65, "z0": 1500.0, "k_factor": 1.5},
             "bedrock_coarse_frac": 0.7,
             "fine_efficiency": 0.3,
             "pitInletBias": {"coarse": 0.8, "fine": 0.1},
-            "Dc": 0.01,
-            "Df": 0.05,
+            "fine_diff_factor": 2.0,
         }
     }
     parser._extraStrata()
     assert parser.stratLith is True
     assert parser.phi0c == 0.45 and parser.z0c == 3000.0
     assert parser.phi0f == 0.65 and parser.z0f == 1500.0
+    assert parser.fine_k_factor == 1.5
     assert parser.bedrock_coarse_frac == 0.7
     assert parser.fine_efficiency == 0.3
     assert parser.pit_inlet_bias_coarse == 0.8
     assert parser.pit_inlet_bias_fine == 0.1
-    assert parser.Dc == 0.01 and parser.Df == 0.05
+    assert parser.fine_diff_factor == 2.0
 
     # ---- Case 3: dual requested but stratigraphy off → forced False
     parser = _strata_parser(stratNb=0)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -775,6 +775,77 @@ def test_dual_all_coarse_matches_single_fraction(
     ), "Stratal thickness diverged from the single-fraction stratigraphy run."
 
 
+@pytest.mark.slow
+def test_dual_mass_conservation(minimal_dual_model):
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 6 — sediment conservation through
+    the dual-lithology pipeline on a closed sphere, and a valid per-fraction
+    partition maintained end-to-end.
+
+    The standard test_mass_conservation SKIPS when stratNb > 0 (compaction
+    moves h without cumED), so dual/stratigraphy-mode total conservation is
+    otherwise untested. cumED only changes via PAIRED sediment erosion/
+    deposition (never by compaction), so on a closed sphere Σ(dcumED·larea)
+    must still vanish relative to the redistributed volume — even with the
+    extra fine-flux solve and the per-pit / marine composition reallocation
+    that dual lithology adds. A real sediment leak (e.g. fine routed but not
+    deposited) would push this to O(0.1+); measured ~1.6e-5 here.
+
+    Per-fraction: the coarse/fine partition must stay valid through erosion,
+    transport, deposition, compaction, advection and diffusion — fine bulk
+    non-negative and never exceeding the layer total; the fine solid phase
+    non-negative; and the pile must actually carry fine (not trivially zero).
+    """
+    model = minimal_dual_model
+
+    # Closed-domain gate (mirrors test_mass_conservation).
+    reasons = []
+    if getattr(model, "flatModel", True):
+        reasons.append("flatModel=True (boundary outflux)")
+    if getattr(model, "tecdata", None) is not None:
+        reasons.append("tectonics active")
+    if getattr(model, "flexOn", False):
+        reasons.append("flexure active")
+    if reasons:
+        pytest.skip(
+            "Dual mass conservation requires a closed sphere with only "
+            "sediment-conserving kernels. This fixture has: " + "; ".join(reasons)
+        )
+    assert model.stratLith and model.stratNb > 0, "fixture must enable dual strat"
+
+    larea = model.larea
+    owned = model.inIDs == 1
+    cumED_before = model.cumEDLocal.getArray().copy()
+
+    model.runProcesses()
+
+    dED = model.cumEDLocal.getArray() - cumED_before
+    from mpi4py import MPI
+    dV = MPI.COMM_WORLD.allreduce(float(np.sum((dED * larea)[owned])), op=MPI.SUM)
+    activity = MPI.COMM_WORLD.allreduce(
+        float(np.sum((np.abs(dED) * larea)[owned])), op=MPI.SUM
+    )
+
+    # ---- Total sediment conserved in dual mode (closed sphere) ----
+    assert activity > 0.0, "no sediment was redistributed; test is vacuous"
+    rel = abs(dV) / activity
+    assert rel < 5.0e-4, (
+        f"Dual-mode sediment not conserved: |ΣdcumED|/activity = {rel:.2e} "
+        f"(> 5e-4). A fraction routed-but-not-deposited would leak here."
+    )
+
+    # ---- Valid per-fraction partition end-to-end ----
+    top = model.stratStep + 1
+    H = model.stratH[:, :top]
+    Hf = model.stratHf[:, :top]
+    assert (Hf >= -1.0e-9).all(), "Negative fine bulk thickness."
+    assert (Hf <= H + 1.0e-6).all(), "Fine bulk exceeds layer total."
+    fine_solid = (Hf * (1.0 - model.phiF[:, :top]))[owned]
+    assert (fine_solid >= -1.0e-9).all(), "Negative fine solid phase."
+    fine_total = MPI.COMM_WORLD.allreduce(float(np.sum(fine_solid)), op=MPI.SUM)
+    assert fine_total > 0.0, "Dual pile carries no fine — sub-system is dead."
+
+
 # ---------------------------------------------------------------------------
 # TEST 2c - channel-evap hook reduces FA (DESIGN_EVAPORATION.md §4 T1)
 # ---------------------------------------------------------------------------

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -655,6 +655,60 @@ def test_dual_lithology_pit_fine_bias():
     )
 
 
+def test_dual_lithology_marine_fine_bias():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 3c — _marineFineFraction biases
+    the marine deposit composition so fine concentrates in deep / distal water
+    and coarse stays proximal (shallow), conserving the marine fine volume.
+    Subaqueous analogue of the pit-fine bias.
+
+    Four marine nodes at increasing water depth, uniform deposit and area,
+    uniform arriving composition (ff_mar = 0.3). The per-node fine fraction
+    must increase with depth and conserve fine volume.
+    """
+    seaplex = pytest.importorskip("gospl.sed.seaplex")
+    n = 4
+
+    class _StubVec:
+        def __init__(self, arr):
+            self._a = np.asarray(arr, dtype=np.float64)
+        def getArray(self):
+            return self._a
+        def setArray(self, a):
+            self._a = np.asarray(a, dtype=np.float64)
+
+    class _StubDM:
+        def globalToLocal(self, g, l):
+            l.setArray(g.getArray().copy())
+
+    m = seaplex.SEAMesh.__new__(seaplex.SEAMesh)
+    m.lpoints = n
+    m.sealevel = 0.0
+    m.inIDs = np.ones(n, dtype=int)
+    m.larea = np.ones(n)
+    m.fineFrac = np.full(n, 0.3)
+    m.depoFineFrac = np.zeros(n)
+    mdep = np.ones(n)                        # uniform marine deposit
+    m.tmp = _StubVec(mdep)
+    m.tmpL = _StubVec(np.zeros(n))
+    m.dm = _StubDM()
+    hl = np.array([-1.0, -3.0, -6.0, -8.0])  # depth = 1, 3, 6, 8
+    sedFlux = np.ones(n)                     # uniform marine input
+
+    m._marineFineFraction(hl, sedFlux)
+
+    depth = m.sealevel - hl
+    ff = m.depoFineFrac
+    order = np.argsort(depth)
+    assert np.all(np.diff(ff[order]) > 0), (
+        f"Marine fine fraction must increase with depth; got {ff}."
+    )
+    fine_vol = float(np.sum(mdep * m.larea * ff))
+    assert np.isclose(fine_vol, 0.3 * n, rtol=1e-9), (
+        f"Marine fine volume not conserved: {fine_vol} != {0.3 * n}"
+    )
+
+
 @pytest.mark.slow
 def test_dual_model_runs_and_invariants(minimal_dual_model):
     """

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -494,15 +494,13 @@ def test_dual_lithology_deposit_and_compaction():
         def globalToLocal(self, g, l):
             l.setArray(g.getArray().copy())
 
-    # ---- Deposition: 4 m deposit, global eroded fine fraction = 1/(3+1) ----
+    # ---- Deposition: 4 m deposit, per-node fine fraction (fineFrac) = 0.25 ----
     m = stratplex.STRAMesh.__new__(stratplex.STRAMesh)
     m.lpoints, m.stratNb, m.stratStep = 1, 2, 1
     m.stratLith = True
     m.memclear = False
     m.phi0c, m.phi0f = 0.49, 0.63
-    m.larea = np.array([1.0])
-    m.thCoarse = np.array([3.0])
-    m.thFine = np.array([1.0])
+    m.fineFrac = np.array([0.25])   # spatially-resolved fine fraction (Phase 3a)
     m.stratH = np.zeros((1, 2))
     m.stratHf = np.zeros((1, 2))
     m.phiS = np.zeros((1, 2))
@@ -514,7 +512,7 @@ def test_dual_lithology_deposit_and_compaction():
     m.deposeStrat()
     assert np.isclose(m.stratH[0, 1], 4.0)
     assert np.isclose(m.stratHf[0, 1], 4.0 * 0.25), (
-        "Fine deposit must equal depo * global eroded fine fraction."
+        "Fine deposit must equal depo * per-node fineFrac."
     )
     assert np.isclose(m.phiF[0, 1], 0.63) and np.isclose(m.phiS[0, 1], 0.49)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -611,6 +611,72 @@ def test_dual_lithology_advection_fine_pile():
     assert np.allclose(m.phiS[:, s], phiS0[:, s])
 
 
+@pytest.mark.slow
+def test_dual_model_runs_and_invariants(minimal_dual_model):
+    """
+    Integration (DESIGN_DUAL_LITHOLOGY.md Phase 6): a full dual-lithology model
+    runs end-to-end and preserves the per-fraction invariants. Exercises the
+    whole dual path together — erodeStrat split, _getSedFlux fine routing
+    (Phase 3a), deposeStrat per-node fineFrac, per-fraction compaction, and
+    fine-pile advection. This is the first live coverage of the dual sediment
+    transport path (both fixtures used by other tests have stratNb == 0).
+    """
+    model = minimal_dual_model
+    assert model.stratLith is True and model.stratNb > 0
+    assert model.stratHf is not None and model.phiF is not None
+    # Bedrock sentinel carries the configured fine split before any run.
+    assert np.isclose(
+        model.stratHf[0, 0], 1.0e6 * (1.0 - model.bedrock_coarse_frac)
+    )
+
+    model.runProcesses()
+
+    top = model.stratStep + 1
+    H = model.stratH[:, :top]
+    Hf = model.stratHf[:, :top]
+    # Fine pile stays physical: non-negative and never exceeding the total.
+    assert (Hf >= -1.0e-9).all(), "Negative fine thickness in the strata pile."
+    assert (Hf <= H + 1.0e-6).all(), "Fine thickness exceeds layer total."
+    # Porosity and the routed fine fraction stay in range.
+    assert (model.phiF[:, :top] >= -1.0e-12).all()
+    assert (model.phiF[:, :top] <= 1.0 + 1.0e-12).all()
+    assert (model.fineFrac >= 0.0).all() and (model.fineFrac <= 1.0).all()
+    # The dual path actually moved fine material (bedrock contributes it).
+    assert float(Hf.sum()) > 0.0
+
+
+@pytest.mark.slow
+def test_dual_all_coarse_matches_single_fraction(
+    minimal_dual_coarse_model, minimal_strat_model
+):
+    """
+    Parity guard (DESIGN_DUAL_LITHOLOGY.md Phase 6): dual lithology configured
+    all-coarse (bedrock_coarse_frac=1.0, no erodibility/diffusivity contrast)
+    must reproduce the single-fraction stratigraphy run exactly. Confirms the
+    dual code paths are a faithful superset of the single-fraction path — any
+    accidental divergence (extra deposition, wrong compaction branch, etc.)
+    trips this.
+    """
+    dual = minimal_dual_coarse_model
+    single = minimal_strat_model
+    dual.runProcesses()
+    single.runProcesses()
+
+    top = min(dual.stratStep, single.stratStep) + 1
+    # No fine produced anywhere in the all-coarse configuration.
+    assert float(dual.stratHf[:, :top].sum()) == 0.0, (
+        "All-coarse dual run produced fine sediment."
+    )
+    # Elevation and stratal thickness must match single-fraction bitwise
+    # (the smoke check measured exactly 0 difference; atol guards float noise).
+    assert np.allclose(
+        dual.hLocal.getArray(), single.hLocal.getArray(), rtol=0.0, atol=1.0e-9
+    ), "Elevation diverged from the single-fraction stratigraphy run."
+    assert np.allclose(
+        dual.stratH[:, :top], single.stratH[:, :top], rtol=0.0, atol=1.0e-9
+    ), "Stratal thickness diverged from the single-fraction stratigraphy run."
+
+
 # ---------------------------------------------------------------------------
 # TEST 2c - channel-evap hook reduces FA (DESIGN_EVAPORATION.md §4 T1)
 # ---------------------------------------------------------------------------

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -500,7 +500,7 @@ def test_dual_lithology_deposit_and_compaction():
     m.stratLith = True
     m.memclear = False
     m.phi0c, m.phi0f = 0.49, 0.63
-    m.fineFrac = np.array([0.25])   # spatially-resolved fine fraction (Phase 3a)
+    m.depoFineFrac = np.array([0.25])   # per-node deposit fine fraction (Phase 3a/3b)
     m.stratH = np.zeros((1, 2))
     m.stratHf = np.zeros((1, 2))
     m.phiS = np.zeros((1, 2))
@@ -609,6 +609,50 @@ def test_dual_lithology_advection_fine_pile():
     # Coarse/total pile still correct (regression on the original behaviour).
     assert np.allclose(m.stratH[:, s], H0[:, s])
     assert np.allclose(m.phiS[:, s], phiS0[:, s])
+
+
+def test_dual_lithology_pit_fine_bias():
+    """
+    Protects: DESIGN_DUAL_LITHOLOGY.md Phase 3b — _pitFineFraction biases the
+    pit/lake deposit composition so fine concentrates toward the depocenter
+    (deep) and coarse toward the inlet/margins (shallow), while conserving the
+    per-pit incoming fine volume.
+
+    Single pit, 4 nodes at increasing bathymetric depth, uniform deposit and
+    area, uniform arriving composition (ff_pit = 0.3). The resulting per-node
+    fine fraction must (a) increase monotonically with depth and (b) conserve
+    the fine volume: Σ(delta·larea·ffrac) == ff_pit·Σ(delta·larea).
+    """
+    sedplex = pytest.importorskip("gospl.sed.sedplex")
+    n = 4
+    m = sedplex.SEDMesh.__new__(sedplex.SEDMesh)
+    m.lpoints = n
+    m.stratLith = True
+    m.pitParams = np.zeros((1, 3))          # one pit
+    m.pitIDs = np.zeros(n, dtype=int)        # all nodes in pit 0
+    m.inIDs = np.ones(n, dtype=int)
+    m.larea = np.ones(n)
+    m.lFill = np.full(n, 10.0)               # rim at 10 m
+    hl = np.array([9.0, 7.0, 4.0, 8.0])      # depth = 1, 3, 6, 2
+    delta = np.ones(n)                       # uniform deposit thickness
+    m.fineFrac = np.full(n, 0.3)
+    m._totFlux = np.ones(n)
+    m.depoFineFrac = np.zeros(n)
+
+    m._pitFineFraction(hl, delta)
+
+    depth = m.lFill - hl
+    ff = m.depoFineFrac
+    # (a) fine fraction increases with depth (depocenter is fine-rich).
+    order = np.argsort(depth)
+    assert np.all(np.diff(ff[order]) > 0), (
+        f"Fine fraction must increase with depth; got {ff} for depth {depth}."
+    )
+    # (b) per-pit fine volume conserved (ff_pit = 0.3, Σ delta*larea = 4).
+    fine_vol = float(np.sum(delta * m.larea * ff))
+    assert np.isclose(fine_vol, 0.3 * 4.0, rtol=1e-9), (
+        f"Pit fine volume not conserved: {fine_vol} != 1.2"
+    )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Dual-lithology: separate transport (Phase 3) + diffusivity (Phase 7) — stacked on #415

Second PR of the dual-lithology feature. **Stacked on `feature/dual-lithology` (#415)** — review that first; this PR's diff is only the Phase 3 + Phase 7 commits. Single-fraction behaviour unchanged; all-coarse dual reproduces single-fraction **bitwise**. Suite: 21 passed, 1 skipped.

Design: `docs/DESIGN_DUAL_LITHOLOGY.md` §3, §7, §8.

### Separate transport (Phase 3)
Replaces the co-transport placeholder (deposit composition = global eroded fraction) with separately-routed fine sediment and spatially-resolved, depth-biased deposit composition, so coarse stays proximal and fine reaches the distal basin / depocenter.

- **3a — separate fine flux**: `_getSedFlux` routes the **total** eroded sediment (`thCoarse+thFine`) into `vSed` — fixing a real bug where the co-transport increment transported only coarse — and routes `thFine` into the new `vSedF`. Per-node `fineFrac = vSedF/vSed` (composition arriving at each node; exact at sinks) replaces the global scalar in `deposeStrat`. New Vecs in `destroy_DMPlex`.
- **Dual fixtures + integration tests**: first end-to-end coverage (both existing fixtures have `stratNb==0`), incl. a **bitwise** all-coarse parity guard.
- **3b — lake/depression**: `_pitFineFraction` biases the pit deposit so fine settles toward the depocenter (bathymetric-depth proxy) and coarse builds the inlet/margins, conserving each pit's fine volume.
- **3c — marine**: `_marineFineFraction` biases the marine deposit so fine concentrates in deep/distal water and coarse stays proximal, conserving the marine fine volume.

### Diffusivity (Phase 7)
- `_surfaceLithoD` (mirrors `_surfaceLithoK`) applies `fine_diff_factor` to the hillslope coefficients in `_hillSlope`/`_hillSlopeNL` so fines diffuse faster subaerially. Marine/lake fresh-deposit diffusion is left alone (3b/3c already handle subaqueous fines-distal — no double-count).
- Fixes a latent design/parser drift: `fine_diff_factor` was in the design doc but never parsed (`_extraStrata` still set the obsolete absolute `Dc`/`Df`). Now parses `strata.fine_diff_factor` as a multiplier on `Cda`/`Cdm`/`nlK`.

### Key design choice (why it's low-risk)
3b/3c are **composition-only**: they bias the deposit's fine fraction by depth (conserving fine volume) without touching the deposit geometry. Elevations/flow are unchanged — the worst case of a bug is a wrong recorded composition, caught by the per-fraction invariant tests. "Fines travel farther" is a depth-biased composition rather than a re-routed flux, avoiding fragile threading through the MPI pit cascade and the nested-matrix marine solve.

### Tests
`test_dual_lithology_pit_fine_bias`, `test_dual_lithology_marine_fine_bias` (monotonic depth-bias + per-fraction volume conservation), plus the end-to-end fixture tests (`test_dual_model_runs_and_invariants`, `test_dual_all_coarse_matches_single_fraction`).

### Not in this PR (follow-ups)
- Fine-enriched overspill (excess overspilling a filled pit should be fine-enriched) — needs threading fine through `_moveDownstream`.
- Soil-coupled diffusion (`diffuseSoil`) not yet composition-weighted.
