### PR TITLE
Output the fine sediment load (sedLoadF) for dual lithology

### DIFF
--- a/docs/HOW_TO_ADD_OUTPUT.md
+++ b/docs/HOW_TO_ADD_OUTPUT.md
@@ -41,6 +41,7 @@ Each rank writes its own partition of the data into `gospl.<step>.p<rank>.h5`. T
 | `flexIso` | `flexIso` | `self.localFlex` (numpy array) | `self.flexOn` |
 | `soilH` | `soilH` | `self.Lsoil.getArray().copy()` (Vec) | `self.cptSoil` |
 | `sedLoad` | `SL` | `self.vSedLocal.getArray().copy()` + floor | always |
+| `sedLoadF` | `SLf` | `self.vSedFLocal.getArray().copy()` + floor (fine sub-flux; coarse = sedLoad − sedLoadF) | `self.stratLith` (dual lithology) |
 | `uplift` | `vTec` | `self.upsub` (numpy array) | `self.upsub is not None` |
 | `rain` | `Rain` | `self.rainVal` (numpy array) | `self.rainVal is not None` |
 | `sea` | `sea` | constant function of `self.sealevel`, no HDF5 dataset | always (XMF only) |
@@ -273,7 +274,7 @@ Add the matching XMF block in `_save_DMPlex_XMF` in the SAME relative position s
 
 ### Restart loop (optional)
 
-`readData` (outmesh.py:401-493) restores the state Vecs from a previous run's HDF5 outputs. Only fields that participate in restarting the simulation appear there — `elev`, `erodep`, `EDrate`, `FA`, `fillFA`, `sedLoad`, optionally `iceH`, `flexIso`, `soilH`.
+`readData` (outmesh.py:401-493) restores the state Vecs from a previous run's HDF5 outputs. Only fields that participate in restarting the simulation appear there — `elev`, `erodep`, `EDrate`, `FA`, `fillFA`, `sedLoad`, optionally `sedLoadF` (dual lithology), `iceH`, `flexIso`, `soilH`.
 
 - **If your field is purely a visualisation output**, do NOT add a read block in `readData`. Restart works fine without it.
 - **If your field is state** (initialised at the start of a fresh run, expected to survive restarts), add a read block mirroring outmesh.py:434-441:

--- a/gospl/tools/outmesh.py
+++ b/gospl/tools/outmesh.py
@@ -378,6 +378,19 @@ class WriteMesh(object):
             data = self.vSedLocal.getArray().copy()
             data[data <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
             f["sedLoad"][:, 0] = data
+            # Dual-lithology fine sediment load (m3/yr). `sedLoad` is the TOTAL
+            # (coarse+fine) flux; `sedLoadF` is the fine sub-flux, so coarse =
+            # sedLoad - sedLoadF. Only written when dual lithology is enabled.
+            if self.stratLith:
+                f.create_dataset(
+                    "sedLoadF",
+                    shape=(self.lpoints, 1),
+                    dtype="float32",
+                    compression="gzip",
+                )
+                dataF = self.vSedFLocal.getArray().copy()
+                dataF[dataF <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
+                f["sedLoadF"][:, 0] = dataF
             if self.upsub is not None:
                 f.create_dataset(
                     "uplift",
@@ -466,6 +479,13 @@ class WriteMesh(object):
             self.dm.localToGlobal(self.cumEDLocal, self.cumED)
             self.vSedLocal.setArray(np.array(hf["/sedLoad"])[:, 0])
             self.dm.localToGlobal(self.vSedLocal, self.vSed)
+            # Restart-safe restore of the fine sediment load (dual lithology).
+            # Older single-fraction outputs have no /sedLoadF; the field is
+            # recomputed each step in _getSedFlux anyway, so a missing dataset
+            # just leaves the init zeros.
+            if self.stratLith and "/sedLoadF" in hf:
+                self.vSedFLocal.setArray(np.array(hf["/sedLoadF"])[:, 0])
+                self.dm.localToGlobal(self.vSedFLocal, self.vSedF)
             self.EbLocal.setArray(np.array(hf["/EDrate"])[:, 0])
             self.dm.localToGlobal(self.EbLocal, self.Eb)
             self.FAL.setArray(np.array(hf["/FA"])[:, 0])
@@ -675,6 +695,19 @@ class WriteMesh(object):
                 'Dimensions="%d 1">%s:/sedLoad</DataItem>\n' % (self.nodes[p], pfile)
             )
             f.write("         </Attribute>\n")
+
+            if self.stratLith:
+                f.write(
+                    '         <Attribute Type="Scalar" Center="Node" Name="SLf">\n'
+                )
+                f.write(
+                    '          <DataItem Format="HDF" NumberType="Float" Precision="4" '
+                )
+                f.write(
+                    'Dimensions="%d 1">%s:/sedLoadF</DataItem>\n'
+                    % (self.nodes[p], pfile)
+                )
+                f.write("         </Attribute>\n")
 
             if self.upsub is not None:
                 f.write(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -20,6 +20,8 @@ EXERCISES public + private methods documented in AGENTS.md.
 
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -888,6 +890,45 @@ def test_dual_fine_conservation(minimal_dual_model):
         f"rel imbalance={rel:.2e} (> 5e-3). A fine-only leak the total-cumED "
         f"test cannot see."
     )
+
+
+@pytest.mark.slow
+def test_dual_sedloadf_output(minimal_dual_model, minimal_strat_model):
+    """
+    Protects: the fine sediment load `sedLoadF` is written to the HDF5 output
+    when dual lithology is enabled, and absent for single-fraction runs.
+    `sedLoad` is the TOTAL flux; `sedLoadF` the fine sub-flux, so
+    0 <= sedLoadF <= sedLoad at every node.
+    """
+    h5py = pytest.importorskip("h5py")
+    import glob
+
+    def _latest_h5(model):
+        files = sorted(
+            glob.glob(os.path.join(str(model.outputDir), "h5", "gospl.*.p*.h5"))
+        )
+        return files[-1] if files else None
+
+    # ---- dual run writes sedLoadF, 0 <= fine <= total ----
+    dual = minimal_dual_model
+    dual.runProcesses()
+    f = _latest_h5(dual)
+    assert f is not None, "no gospl HDF5 output was written"
+    with h5py.File(f, "r") as hf:
+        assert "sedLoadF" in hf, "sedLoadF missing from dual-lithology output"
+        sl = np.array(hf["sedLoad"])[:, 0]
+        slf = np.array(hf["sedLoadF"])[:, 0]
+    assert (slf >= 0.0).all(), "negative fine sediment load"
+    assert (slf <= sl + 1.0e-6).all(), "fine load exceeds total load"
+
+    # ---- single-fraction stratigraphy run must NOT write sedLoadF ----
+    single = minimal_strat_model
+    single.runProcesses()
+    fs = _latest_h5(single)
+    with h5py.File(fs, "r") as hf:
+        assert "sedLoad" in hf and "sedLoadF" not in hf, (
+            "single-fraction output must not contain sedLoadF"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Output the fine sediment load (`sedLoadF`)

Small follow-up: the dual-lithology fine sediment flux (`vSedF`) was computed but not written out. This adds it to the HDF5 output so the coarse/fine split is visible in post-processing.

- `sedLoad` is the **total** (coarse+fine) flux; the new `sedLoadF` is the **fine** sub-flux, so **coarse = sedLoad − sedLoadF**.
- Written in `_outputMesh` (gated on `self.stratLith`; XMF attribute `SLf`), restored on restart when present (older single-fraction outputs lack it and are unaffected — the field is recomputed each step anyway).
- `HOW_TO_ADD_OUTPUT.md` updated (output-field table + restart list).

**Test:** `test_dual_sedloadf_output` — a dual run writes `sedLoadF` with `0 ≤ sedLoadF ≤ sedLoad` everywhere; a single-fraction stratigraphy run does **not** write it. Single-fraction output is unchanged. Full suite: 24 passed, 1 skipped.
