### PR TITLE
Ice sheet (SIA) PR-B: glacial erosion + till [stacked on PR-A]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ MANIFEST
 fortran/meshparams.mod
 tests/fixtures/minimal_ice_sia/
 tests/fixtures/minimal_ice_mfd/
+tests/fixtures/minimal_ice_till/

--- a/gospl/eroder/SPL.py
+++ b/gospl/eroder/SPL.py
@@ -355,7 +355,10 @@ class SPL(object):
         (abrasion is subglacial; no marine abrasion) and to ice presence
         (``iceUbL`` is already zero where there is no ice).
         """
-        if not (self.iceOn and self.iceSIA) or self.ice_Kg <= 0.0:
+        # When till handling is on, abrasion is routed to till (deposited as
+        # moraine in the ablation zone) by iceplex.glacialTill instead of
+        # straight into the fluvial sediment system — mutually exclusive here.
+        if not (self.iceOn and self.iceSIA) or self.ice_Kg <= 0.0 or self.ice_till_on:
             return
         ub = self.iceUbL.getArray()
         abr = self.ice_Kg * np.power(np.maximum(ub, 0.0), self.ice_abr_l)

--- a/gospl/eroder/SPL.py
+++ b/gospl/eroder/SPL.py
@@ -338,6 +338,34 @@ class SPL(object):
 
         return
 
+    def _glacialAbrasion(self):
+        r"""
+        Velocity-based glacial abrasion (SIA ice model, Phase 3).
+
+        Adds a bed-lowering term :math:`E_g = K_g\,|u_b|^{l}` (m/yr) to the
+        erosion-deposition rate ``self.Eb`` as an incision (negative, the Eb
+        thickness-rate convention), where :math:`u_b` is the SIA basal sliding
+        speed (``self.iceUbL``, Phase 2). The eroded material then flows into the
+        sediment system through the standard ``Eb·dt`` → cumED / hGlobal /
+        erodeStrat path in the SPL wrappers (no separate bookkeeping).
+
+        No-op unless dual ice flow is on in SIA mode with ``Kg > 0``. Under SIA
+        the legacy stream-power glacial term ``Ki·F^m`` is inactive (iceFAL is
+        zeroed), so the two laws never double-count. Masked to subaerial cells
+        (abrasion is subglacial; no marine abrasion) and to ice presence
+        (``iceUbL`` is already zero where there is no ice).
+        """
+        if not (self.iceOn and self.iceSIA) or self.ice_Kg <= 0.0:
+            return
+        ub = self.iceUbL.getArray()
+        abr = self.ice_Kg * np.power(np.maximum(ub, 0.0), self.ice_abr_l)
+        abr[self.seaID] = 0.0
+        self.tmpL.setArray(-abr)                 # incision (negative), local
+        self.dm.localToGlobal(self.tmpL, self.tmp)
+        self.Eb.axpy(1.0, self.tmp)              # Eb += (-abrasion)
+        self.dm.globalToLocal(self.Eb, self.EbLocal)
+        return
+
     def erodepSPL(self):
         """
         Modified **stream power law** model used to represent erosion by rivers also taking into account the role played by sediment in modulating erosion and deposition rate.
@@ -353,6 +381,7 @@ class SPL(object):
         self.hGlobal.copy(result=self.hOld)
         self.dm.globalToLocal(self.hOld, self.hOldLocal)
         self._getEroDepRate()
+        self._glacialAbrasion()
 
         # Get erosion / deposition thicknesses (Eb is in thickness rate
         # convention: positive deposition, negative incision; so Eb*dt is

--- a/gospl/eroder/nlSPL.py
+++ b/gospl/eroder/nlSPL.py
@@ -402,6 +402,7 @@ class nlSPL(object):
         self.hGlobal.copy(result=self.hOld)
         self.dm.globalToLocal(self.hOld, self.hOldLocal)
         self._getEroDepRateNL()
+        self._glacialAbrasion()
 
         # Get erosion / deposition thicknesses (Eb is in thickness rate
         # convention: positive deposition, negative incision). See SPL.py.

--- a/gospl/eroder/soilSPL.py
+++ b/gospl/eroder/soilSPL.py
@@ -324,6 +324,7 @@ class soilSPL(object):
         self.hGlobal.copy(result=self.hOld)
         self.dm.globalToLocal(self.hOld, self.hOldLocal)
         self._getEroDepRateSoil()
+        self._glacialAbrasion()
 
         # Get erosion / deposition thicknesses (Eb is in thickness rate
         # convention: positive deposition, negative incision). See SPL.py.

--- a/gospl/flow/iceplex.py
+++ b/gospl/flow/iceplex.py
@@ -62,6 +62,10 @@ class IceMesh(object):
             self.iceHL.set(0.0)
             self.iceMeltL.set(0.0)
             self.iceUbL.set(0.0)
+            # Glacial-till mass-balance diagnostics (m^3, owned-node running
+            # totals reduced by the till-conservation test).
+            self._tillEroded = 0.0
+            self._tillDeposited = 0.0
             # Cached SIA implicit-solver handles (created lazily on first use;
             # destroyed in destroy_DMPlex).
             self._snes_ice = None
@@ -461,6 +465,76 @@ class IceMesh(object):
         if MPIrank == 0 and self.verbose:
             print(
                 "Glaciers Accumulation (%0.02f seconds)" % (process_time() - ti),
+                flush=True,
+            )
+
+        return
+
+    def glacialTill(self):
+        r"""
+        Glacial till — production, transport and deposition (Phase 4, SIA only).
+
+        Glacial abrasion (:math:`E_g = K_g |u_b|^l`) erodes rock under sliding
+        ice; the abraded material becomes **till** carried by the ice and
+        deposited where the ice **melts out** — the ablation zone / terminal
+        moraine. The bed is therefore **lowered** under fast ice and **raised**
+        in the ablation zone, conserving rock volume exactly (the net bed change
+        is zero by construction): a transport, not a source/sink.
+
+        Conservation is structural: the total abraded volume ``Vtot`` is
+        redistributed to the ablation cells weighted by the meltwater rate
+        (``iceMeltL``), so ``Σ deposited == Vtot``. Guarded by a dedicated
+        till-conservation test (the dual-lithology lesson: a volume the total
+        budget can't see needs its own guard).
+
+        Active only with ``flow_model: sia``, ``till.on`` and ``Kg > 0``; a
+        no-op otherwise, so existing behaviour is unchanged.
+
+        Simplifications (v1, documented): till deposits across the ablation zone
+        weighted by melt rather than routed per ice-catchment to each terminus;
+        and it operates on the bulk bed (cumED/elevation), not yet the
+        stratigraphic pile — couple to stratigraphy / dual lithology later.
+        """
+        if not (self.iceOn and self.iceSIA and self.ice_till_on) or self.ice_Kg <= 0.0:
+            return
+
+        ti = process_time()
+        ub = self.iceUbL.getArray()
+        Eg = self.ice_Kg * np.power(np.maximum(ub, 0.0), self.ice_abr_l)  # m/yr
+        Eg[self.seaID] = 0.0
+        Vero = Eg * self.dt * self.larea                  # abraded volume (m^3) per cell
+        owned = self.inIDs == 1
+        Vtot = MPI.COMM_WORLD.allreduce(float(np.sum(Vero[owned])), op=MPI.SUM)
+
+        melt = self.iceMeltL.getArray()                   # ablation water volume (m^3/yr)
+        Wtot = MPI.COMM_WORLD.allreduce(float(np.sum(melt[owned])), op=MPI.SUM)
+
+        # No abrasion or no ablation zone to receive the till -> nothing happens
+        # (skipping the erosion too keeps it conservative: no orphaned till).
+        if Vtot <= 0.0 or Wtot <= 0.0:
+            return
+
+        # Bed change (m): erode at abrasion cells, deposit the till where ice
+        # melts, weighted by melt. Σ(dz·area) == 0 (rock moved, not created).
+        dz = -Eg * self.dt
+        dz_dep = (Vtot * melt / Wtot) / self.larea
+        dz = dz + dz_dep
+
+        self.tmpL.setArray(dz)
+        self.dm.localToGlobal(self.tmpL, self.tmp)
+        self.cumED.axpy(1.0, self.tmp)
+        self.hGlobal.axpy(1.0, self.tmp)
+        self.dm.globalToLocal(self.cumED, self.cumEDLocal)
+        self.dm.globalToLocal(self.hGlobal, self.hLocal)
+
+        self._tillEroded += Vtot
+        self._tillDeposited += MPI.COMM_WORLD.allreduce(
+            float(np.sum((dz_dep * self.larea)[owned])), op=MPI.SUM
+        )
+
+        if MPIrank == 0 and self.verbose:
+            print(
+                "Glacial Till (%0.02f seconds)" % (process_time() - ti),
                 flush=True,
             )
 

--- a/gospl/model.py
+++ b/gospl/model.py
@@ -250,6 +250,13 @@ class Model(
                     # Non-linear slope dependencies
                     _nlSPL.erodepSPLnl(self)
 
+                # Glacial till: abrasion-produced till transported by ice and
+                # deposited (melt-out) as moraine in the ablation zone (SIA +
+                # till only; no-op otherwise). Done before fluvial deposition
+                # so the moraine is reworked by meltwater/rivers this step.
+                if self.iceOn:
+                    _IceMesh.glacialTill(self)
+
                 if not self.nodep:
                     # Downstream sediment deposition over the continents
                     _FAMesh.flowAccumulation(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,16 @@ def minimal_ice_sia_model():
 
 
 @pytest.fixture
+def minimal_ice_till_model():
+    """
+    Minimal SIA model with glacial abrasion + till on (`ice.abrasion.Kg`,
+    `ice.till.on`). Exercises the till production/transport/deposition path.
+    See minimal_ice_till.yml.
+    """
+    return _instantiate("minimal_ice_till.yml")
+
+
+@pytest.fixture
 def minimal_ice_mfd_model():
     """
     Minimal model with the default MFD flow-routing ice proxy (no flow_model

--- a/tests/fixtures/minimal_ice_till.yml
+++ b/tests/fixtures/minimal_ice_till.yml
@@ -1,0 +1,49 @@
+name: minimal SIA ice + glacial till test
+
+domain:
+    npdata: ['mesh','v','c','z']
+    flowdir: 2
+    bc: '1111'
+    seadepo: True
+    nodep: False
+
+time:
+    start: 0.
+    end: 100
+    tout: 50
+    dt: 10.
+
+spl:
+    K: 4.0e-6
+    d: 0.
+    m: 0.5
+    G: 0.
+
+diffusion:
+    hillslopeKa: 0.01
+    hillslopeKm: 0.2
+
+ice:
+    flow_model: sia
+    hela: 2000.
+    hice: 3000.
+    hterm: 1500.
+    sia:
+        Aglen: 1.0e-16
+        slide: 1.0e-3
+        glen: 3.0
+    abrasion:
+        Kg: 1.0e-4
+        l: 1.0
+    till:
+        on: True
+
+sea:
+    position: -100.
+
+climate:
+  - start: 0.
+    uniform: 1
+
+output:
+    dir: 'minimal_ice_till'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -428,6 +428,62 @@ def test_ice_glacial_abrasion(minimal_ice_sia_model):
     assert np.allclose(EbL[~sliding], 0.0, atol=1.0e-9), "abrasion outside ice"
 
 
+@pytest.mark.slow
+def test_ice_glacial_till_conserves(minimal_ice_till_model):
+    """
+    Protects: DESIGN_ICE_SHEET.md Phase 4 — glacial till is a conservative
+    bed-to-bed transport: abrasion lowers the bed under sliding ice and the
+    till is deposited (melt-out) in the ablation zone, so the NET bed-volume
+    change is zero (rock moved, not created/destroyed). This is the till
+    analogue of the dual-lithology fine-conservation guard — a volume the total
+    sediment budget cannot see needs its own check.
+
+    The full model runs end-to-end with till on (smoke), then `glacialTill` is
+    driven with an imposed sliding-velocity + meltwater field for a
+    deterministic conservation check.
+    """
+    m = minimal_ice_till_model
+    assert m.iceSIA and m.ice_till_on and m.ice_Kg > 0.0
+    # Full SIA + till run must not break.
+    m.runProcesses()
+
+    # Deterministic conservation check: fast ice up high, ablation band lower.
+    from mpi4py import MPI
+    zbed = m.hLocal.getArray().copy()
+    m.iceUbL.setArray(np.where(zbed > 2500.0, 0.1, 0.0))
+    m.iceMeltL.setArray(np.where((zbed > 1500.0) & (zbed < 2000.0), 1.0, 0.0))
+    larea = m.larea
+    owned = m.inIDs == 1
+
+    cum0 = m.cumEDLocal.getArray().copy()
+    m._tillEroded = 0.0
+    m._tillDeposited = 0.0
+    m.glacialTill()
+    dcum = m.cumEDLocal.getArray() - cum0
+
+    ero = MPI.COMM_WORLD.allreduce(m._tillEroded, op=MPI.SUM)
+    dep = MPI.COMM_WORLD.allreduce(m._tillDeposited, op=MPI.SUM)
+    netvol = MPI.COMM_WORLD.allreduce(
+        float(np.sum((dcum * larea)[owned])), op=MPI.SUM
+    )
+    activity = MPI.COMM_WORLD.allreduce(
+        float(np.sum((np.abs(dcum) * larea)[owned])), op=MPI.SUM
+    )
+
+    assert ero > 0.0, "no till was produced; test is vacuous"
+    # Rock is conserved: eroded volume == deposited volume.
+    assert np.isclose(ero, dep, rtol=1.0e-9), "till eroded != till deposited"
+    # Net bed-volume change is zero relative to the rock moved.
+    assert abs(netvol) / activity < 1.0e-6, (
+        f"glacial till not volume-conserving: net={netvol:.3e} activity={activity:.3e}"
+    )
+    # Bed lowered under fast ice, raised in the ablation zone.
+    assert (dcum[zbed > 2500.0] <= 1.0e-9).all(), "no abrasion under fast ice"
+    assert (dcum[(zbed > 1500.0) & (zbed < 2000.0)] >= -1.0e-9).all(), (
+        "no till deposition in the ablation zone"
+    )
+
+
 def _strata_parser(stratNb):
     """
     Bare parser primed for `_extraStrata`: it reads `self.input`,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -394,6 +394,40 @@ def test_ice_sia_implicit_matches_explicit(minimal_ice_sia_model):
     )
 
 
+@pytest.mark.slow
+def test_ice_glacial_abrasion(minimal_ice_sia_model):
+    """
+    Protects: DESIGN_ICE_SHEET.md Phase 3 — velocity-based glacial abrasion
+    E = Kg·|u_b|^l adds incision to Eb exactly where ice slides (and only there),
+    and is a no-op when Kg = 0.
+
+    Drives _glacialAbrasion with a known basal-velocity field so the result is
+    analytic: Eb = −Kg·u_b (l=1) on the sliding cells, 0 elsewhere.
+    """
+    m = minimal_ice_sia_model
+    zbed = m.hLocal.getArray().copy()
+    ub = np.where(zbed > 2000.0, 0.1, 0.0)     # 0.1 m/yr sliding above 2000 m
+    m.iceUbL.setArray(ub.copy())
+    m.ice_abr_l = 1.0
+
+    # Kg = 0 -> no abrasion.
+    m.ice_Kg = 0.0
+    m.Eb.set(0.0)
+    m._glacialAbrasion()
+    assert np.allclose(m.Eb.getArray(), 0.0), "abrasion must be a no-op when Kg=0"
+
+    # Kg > 0 -> incision E = -Kg·u_b where ice slides (all above sea here).
+    m.ice_Kg = 1.0e3
+    m.Eb.set(0.0)
+    m._glacialAbrasion()
+    EbL = m.EbLocal.getArray()
+    sliding = ub > 0.0
+    assert np.allclose(EbL[sliding], -1.0e3 * ub[sliding], rtol=1.0e-6, atol=1.0e-9), (
+        "abrasion incision must equal -Kg*|u_b|^l where ice slides"
+    )
+    assert np.allclose(EbL[~sliding], 0.0, atol=1.0e-9), "abrasion outside ice"
+
+
 def _strata_parser(stratNb):
     """
     Bare parser primed for `_extraStrata`: it reads `self.input`,


### PR DESCRIPTION
Second stacked PR (on PR-A). Glacial **erosion and deposition**.

- **Phase 3** — velocity-based glacial **abrasion** `E = Kg·|u_b|^l` (using the Phase-2 basal velocity) added to the erosion step across all three SPL flavours; flows into the sediment system via the standard `Eb·dt → cumED/erodeStrat` path. Verified `Eb = −Kg·u_b` exactly on sliding cells.
- **Phase 4** — glacial **till**: abrasion produces till carried by the ice and deposited (melt-out) in the ablation zone (terminal moraine). **Conservative by construction** — the abraded volume is redistributed to ablation cells weighted by meltwater, so the net bed-volume change is exactly zero (rock moved, not created). Mutually exclusive with the Phase-3 fluvial-abrasion path (no double-count). Guarded by a dedicated **till mass-conservation test** (net bed change ~1e-16 rel).

SIA-only and gated; MFD-proxy/ice-off unchanged.