### PR TITLE
Ice sheet (SIA) PR-C: flexural loading + output [stacked on PR-B]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ fortran/meshparams.mod
 tests/fixtures/minimal_ice_sia/
 tests/fixtures/minimal_ice_mfd/
 tests/fixtures/minimal_ice_till/
+tests/fixtures/minimal_ice_flex/

--- a/docs/DESIGN_ICE_SHEET.md
+++ b/docs/DESIGN_ICE_SHEET.md
@@ -117,8 +117,8 @@ Parsed in `inputparser._extraIce` (extend; mandatory-continuation contract).
 | **2** | Expose basal/sliding velocity `|u_b|` per cell from the SIA solve. | `iceplex.py`, maybe `ice_flux` companion | medium |
 | **3** | Velocity-based abrasion `Kg·|u_b|^l` in the erosion step (gated; replaces/【supplements】the `Ki·F^m` proxy under `flow_model: sia`). | `eroder/SPL.py`/`nlSPL.py`/`soilSPL.py` | medium |
 | **4** | Till: production from abrasion → advect with ice flux → deposit at melt/terminus (moraine) → hand melt-zone till to meltwater. Per-step till mass-conservation guard. | `iceplex.py`, `flowplex.py`, `sedplex` hand-off | **high** |
-| **5** | Loading: feed SIA `iceH` to flexure (mostly exists); optional separate ice-load density. | `addprocess.py` | low |
-| **6** | Output (`iceH`, basal velocity, `tillH`) + restart; fixtures + tests (analytical dome, abrasion sign, till conservation, ice-off/MFD parity). | `outmesh.py`, `tests/` | medium |
+| **5** | ✅ DONE. Loading works through the **existing** `applyFlexure` unchanged: the `iceFlex` snapshot is taken before the SIA update, so `dIce = iceHL − iceFlex` (×910/`rhoc`) loads the plate with the SIA thickness. Verified: SIA+global flexure produces isostatic subsidence under ice. | `addprocess.py` (no change) | low |
+| **6** | ✅ DONE. Output: `iceUb` (basal velocity) added (`iceH` already written). Tests: SIA invariants, implicit≡explicit, glacial-abrasion sign, till volume conservation, **ice-volume conservation under zero SMB (Halfar-style flux check)**, flexure loading, MFD/ice-off parity. *Quantitative transient Halfar dome on a flat-bed fixture remains a deeper future validation.* | `outmesh.py`, `tests/` | medium |
 
 **Recommended PR grouping:** PR-A = Phases 0–2 (dynamics + velocity, the new ice engine, validated against the dome); PR-B = Phases 3–4 (erosion + till); PR-C = Phases 5–6 (loading + output + tests). Stack like the dual-lithology PRs.
 

--- a/gospl/tools/outmesh.py
+++ b/gospl/tools/outmesh.py
@@ -352,6 +352,17 @@ class WriteMesh(object):
                     data[self.seaID] = 1.0
                 f["iceH"][:, 0] = data
 
+                # SIA basal sliding speed (m/yr). Zero under the MFD proxy;
+                # the abrasion driver and a diagnostic of ice dynamics.
+                if self.iceSIA:
+                    f.create_dataset(
+                        "iceUb",
+                        shape=(self.lpoints, 1),
+                        dtype="float32",
+                        compression="gzip",
+                    )
+                    f["iceUb"][:, 0] = self.iceUbL.getArray().copy()
+
             if self.flexOn:
                 f.create_dataset(
                     "flexIso",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,16 @@ def minimal_ice_till_model():
 
 
 @pytest.fixture
+def minimal_ice_flex_model():
+    """
+    Minimal SIA model with global flexural isostasy on. Confirms the SIA ice
+    thickness feeds the existing ice-loading path in applyFlexure. See
+    minimal_ice_flex.yml.
+    """
+    return _instantiate("minimal_ice_flex.yml")
+
+
+@pytest.fixture
 def minimal_ice_mfd_model():
     """
     Minimal model with the default MFD flow-routing ice proxy (no flow_model

--- a/tests/fixtures/minimal_ice_flex.yml
+++ b/tests/fixtures/minimal_ice_flex.yml
@@ -1,0 +1,48 @@
+name: minimal SIA ice + flexure test
+
+domain:
+    npdata: ['mesh','v','c','z']
+    flowdir: 2
+    bc: '1111'
+    seadepo: True
+    nodep: False
+
+time:
+    start: 0.
+    end: 100
+    tout: 50
+    dt: 10.
+
+spl:
+    K: 4.0e-6
+    d: 0.
+    m: 0.5
+    G: 0.
+
+diffusion:
+    hillslopeKa: 0.01
+    hillslopeKm: 0.2
+
+ice:
+    flow_model: sia
+    hela: 2000.
+    hice: 3000.
+    hterm: 1500.
+
+flexure:
+    method: global
+    rhoa: 3300.
+    thick: 10000.
+    rhoc: 2300.
+    young: 6.5e10
+    res_deg: 2.0
+
+sea:
+    position: -100.
+
+climate:
+  - start: 0.
+    uniform: 1
+
+output:
+    dir: 'minimal_ice_flex'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -484,6 +484,64 @@ def test_ice_glacial_till_conserves(minimal_ice_till_model):
     )
 
 
+@pytest.mark.slow
+def test_ice_sia_volume_conservation(minimal_ice_sia_model):
+    """
+    Protects: DESIGN_ICE_SHEET.md Phase 6 — the SIA ice flux is mass-conservative
+    (it redistributes ice, it does not create or destroy it). Halfar-style check:
+    with zero surface mass balance and the terminus clamp disabled, stepping an
+    ice dome must conserve ice volume to the flux-numerics floor.
+    """
+    from mpi4py import MPI
+    m = minimal_ice_sia_model
+    zbed = m.hLocal.getArray().copy()
+    m.rainVal = np.zeros_like(m.rainVal)       # zero SMB -> pure flux redistribution
+    m.iceT = lambda t: 0.0                     # disable terminus clamp
+    H0 = np.where(zbed > 2500.0, 300.0, 0.0)
+    owned = m.inIDs == 1
+    larea = m.larea
+
+    V0 = MPI.COMM_WORLD.allreduce(float(np.sum((H0 * larea)[owned])), op=MPI.SUM)
+    m.iceHL.setArray(H0.copy())
+    m._iceFlowSIAImplicit(0.0, 1000.0, 0.0)    # elaH, iceH, iceT
+    H1 = m.iceHL.getArray()
+    V1 = MPI.COMM_WORLD.allreduce(float(np.sum((H1 * larea)[owned])), op=MPI.SUM)
+
+    assert V0 > 0.0
+    assert abs(V1 - V0) / V0 < 1.0e-4, (
+        f"SIA flux not volume-conserving: V0={V0:.4e} V1={V1:.4e}"
+    )
+    # The flux actually moved ice (not a frozen field).
+    assert float(np.max(np.abs(H1 - H0))) > 0.0
+
+
+@pytest.mark.slow
+def test_ice_sia_flexure_loading(minimal_ice_flex_model):
+    """
+    Protects: DESIGN_ICE_SHEET.md Phase 5 — the SIA ice thickness feeds the
+    existing flexural-isostasy ice load (applyFlexure converts the iceHL change
+    to an equivalent sediment load). The run produces a finite flexural field
+    with subsidence (negative deflection) under the load.
+    """
+    import glob
+    model = minimal_ice_flex_model
+    assert model.iceSIA and model.flexOn
+    model.runProcesses()
+
+    flx = model.localFlex
+    assert np.isfinite(flx).all(), "flexural field non-finite"
+    assert float(flx.min()) < 0.0, "no subsidence — ice/sediment load not applied"
+
+    # SIA basal-velocity output is written (Phase 6).
+    files = sorted(
+        glob.glob(os.path.join(str(model.outputDir), "h5", "gospl.*.p*.h5"))
+    )
+    if files:
+        h5py = pytest.importorskip("h5py")
+        with h5py.File(files[-1], "r") as hf:
+            assert "iceUb" in hf, "SIA basal-velocity field iceUb not in output"
+
+
 def _strata_parser(stratNb):
     """
     Bare parser primed for `_extraStrata`: it reads `self.input`,


### PR DESCRIPTION
Third stacked PR (on PR-B). Loading, output, validation.

- **Phase 5** — flexural **ice loading** works through the existing `applyFlexure` unchanged: the `iceFlex` snapshot is taken before the SIA update, so `dIce = iceHL − iceFlex` (×910/`rhoc`) loads the plate with the SIA thickness. Verified: SIA + global flexure → isostatic subsidence under ice.
- **Phase 6** — output: SIA basal speed `iceUb` written (`iceH` already was). Validation tests: **ice-volume conservation under zero SMB** (Halfar-style — the flux is mass-conservative, ~5e-6) and **flexure loading**.

8 ice tests total across the three PRs. Remaining (noted, not a gap): a quantitative transient Halfar dome on a flat-bed fixture as deeper validation.