### PR TITLE
ice: terminus floor = max(hterm, sea level), default to sea level

### DIFF
--- a/docs/ICE_SHEET_SUMMARY.md
+++ b/docs/ICE_SHEET_SUMMARY.md
@@ -120,7 +120,8 @@ The `ice` section is the opt-in. SIA is the only model, so the previous
 ice:
     hela: 1850.0          # equilibrium-line altitude (m)
     hice: 2100.0          # ice-cap altitude (m)
-    hterm: 1700.0         # glacier terminus (m)   [or evol: <csv>]
+    hterm: 1700.0         # glacier terminus (m); floor = max(hterm, sea level),
+                          #   defaults to sea level if omitted  [or evol: <csv>]
     sia:
         Aglen: 1.0e-16    # Glen rate factor
         slide: 1.0e-3     # basal sliding coefficient

--- a/docs/tech_guide/ice.rst
+++ b/docs/tech_guide/ice.rst
@@ -83,10 +83,13 @@ using a cached, Jacobian-free PETSc ``SNES`` (``ngmres`` with a CG / HYPRE
 BoomerAMG inner solve) — the same non-linear-diffusion machinery as the
 non-linear hillslope solver. The scheme is unconditionally stable, so it takes
 the **full goSPL time step in one solve**. The free boundary :math:`H \ge 0` is
-enforced by clamping after convergence, and ice is removed below the glacier
-terminus elevation (``hterm``). The solver is validated against the analytical
-SIA dome: with zero surface mass balance the flux conserves ice volume to the
-numerical floor.
+enforced by clamping after convergence, and ice is removed below the terminus
+floor :math:`\max(h_\mathrm{term}, \text{sea level})` — so it never persists
+below the (possibly time-varying) sea surface, and an ``hterm`` below sea level
+is raised to it. When ``hterm`` is omitted the floor is simply the sea-level
+position, leaving the dynamics and ablation to set the terminus. The solver is
+validated against the analytical SIA dome: with zero surface mass balance the
+flux conserves ice volume to the numerical floor.
 
 From the converged thickness, goSPL derives the **basal sliding speed**
 :math:`u_b` (``ice_velocity`` kernel), which is written to the output as

--- a/docs/user_guide/surfproc.rst
+++ b/docs/user_guide/surfproc.rst
@@ -151,7 +151,7 @@ Ice sheets and glacial erosion
         The equilibrium-line / ice-cap geometry controls where ice accumulates
         and melts:
 
-        a. ``hterm`` is the glacier terminus elevation (m) — no ice is kept below it,
+        a. ``hterm`` is the glacier terminus elevation (m) — no ice is kept below it. The effective floor is ``max(hterm, sea level)``: ice never persists below the (possibly time-varying) sea surface, and a ``hterm`` below sea level is raised to it. When omitted, the terminus defaults to the **sea-level position**, so the SIA dynamics and ablation set the actual terminus,
         b. ``hela`` is the equilibrium-line altitude (m) — ablation below, accumulation above,
         c. ``hice`` is the ice-cap altitude (m) — full precipitation is captured as ice above it.
 

--- a/gospl/flow/iceplex.py
+++ b/gospl/flow/iceplex.py
@@ -129,9 +129,16 @@ class IceMesh(object):
         Common post-solve steps for the SIA solve: terminus clamp, store the
         ice thickness and the basal sliding speed (the abrasion driver), and
         capture ablation meltwater (m^3/yr) for the river coupling.
+
+        The terminus floor is ``max(hterm, sea level)``: ice is removed below
+        the prescribed terminus and, regardless, below the (possibly
+        time-varying) sea surface — no land ice persists offshore (there is no
+        marine-ice / calving model). When ``hterm`` is unprescribed (the
+        ``TERMINUS_UNSET`` sentinel) the floor is simply the sea-level position.
         """
         H = np.maximum(H, 0.0)
-        H[zbed < iceT] = 0.0
+        terminus = np.maximum(iceT, self.sealevel)
+        H[zbed < terminus] = 0.0
         self.iceHL.setArray(H)
         # Basal sliding speed from the converged thickness (steepest-descent
         # SIA velocity); zero where there is no ice.

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -12,6 +12,12 @@ if "READTHEDOCS" not in os.environ:
 
 MPIrank = petsc4py.PETSc.COMM_WORLD.Get_rank()
 
+# Sentinel for an unprescribed glacier terminus altitude (``ice.hterm``): the
+# effective terminus floor is then the sea-level position (see
+# iceplex._iceSIAFinalize). Any value safely below the lowest plausible sea
+# level works.
+TERMINUS_UNSET = -1.0e10
+
 
 class ReadYaml(object):
     """
@@ -1665,7 +1671,12 @@ class ReadYaml(object):
             glaciers = iceDict.get("glaciers")
             elaH = iceDict.get("hela", 2000.0)
             iceH = iceDict.get("hice", 2400.0)
-            iceT = iceDict.get("hterm", 1800.0)
+            # Terminus: the effective floor is max(hterm, sea level), applied in
+            # iceplex._iceSIAFinalize. The SIA dynamics + ablation set where the
+            # glacier actually ends; the clamp only stops land ice persisting
+            # below the (possibly time-varying) sea surface. The sentinel below
+            # means "not prescribed" -> defaults to the sea-level position.
+            iceT = iceDict.get("hterm", TERMINUS_UNSET)
 
             # Initial (pre-existing) ice thickness — scalar or [file, key] map.
             hinit = iceDict.get("hinit")
@@ -1761,7 +1772,7 @@ class ReadYaml(object):
         series = []
         for ev in events:
             interval = {"start": ev["start"]}
-            for fld, default in (("hela", 2000.0), ("hice", 2400.0), ("hterm", 1800.0)):
+            for fld, default in (("hela", 2000.0), ("hice", 2400.0), ("hterm", TERMINUS_UNSET)):
                 sc, spec = self._iceGeomField(ev.get(fld, default))
                 if spec is not None:
                     self._checkMap(spec, "ice %s" % fld)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -277,6 +277,9 @@ def test_ice_opt_in():
     assert p.iceOn is True
     assert p.sia_Aglen == 1.0e-16 and p.sia_glen == 3.0
     assert p.ice_Kg == 0.0 and p.ice_till_on is False
+    # Terminus is unprescribed -> sentinel, resolved to the sea-level position
+    # at runtime (so ice is not silently truncated above sea level).
+    assert float(p.iceT(p.tStart)) < -1.0e9
 
     # ---- Case 3: full SIA parameters ----
     p = _ice_parser()
@@ -374,6 +377,38 @@ def test_ice_seed_and_evolve(minimal_ice_seed_model):
     # Still a valid ice field after evolving the seed.
     assert np.isfinite(H).all() and (H >= -1.0e-9).all()
     assert float(H.max()) > 0.0, "seeded ice vanished entirely"
+
+
+@pytest.mark.slow
+def test_ice_terminus_sea_level_floor(minimal_ice_sia_model):
+    """
+    Protects: the terminus floor is max(hterm, sea level) — no land ice persists
+    below the sea surface, and a prescribed hterm below sea level is raised to
+    sea level. The unprescribed default resolves to the sea-level position.
+    """
+    m = minimal_ice_sia_model
+    zbed = m.hLocal.getArray().copy()
+    n = m.lpoints
+    H_in = np.full(n, 100.0)            # ice everywhere to start
+    mdot0 = np.zeros(n)
+
+    # Sea level at 500 m; terminus unprescribed (sentinel) -> floor = sea level.
+    m.sealevel = 500.0
+    m._iceSIAFinalize(H_in.copy(), zbed, mdot0, -1.0e10, m.sia_slide, m.sia_glen)
+    H = m.iceHL.getArray()
+    assert (H[zbed < 500.0] == 0.0).all(), "ice kept below sea level"
+    if (zbed >= 500.0).any():
+        assert (H[zbed >= 500.0] > 0.0).any(), "ice wrongly removed above sea level"
+
+    # Prescribed hterm BELOW sea level is raised to sea level (floor stays 500).
+    m._iceSIAFinalize(H_in.copy(), zbed, mdot0, 100.0, m.sia_slide, m.sia_glen)
+    H = m.iceHL.getArray()
+    assert (H[zbed < 500.0] == 0.0).all(), "hterm below sea level not raised to sea level"
+
+    # Prescribed hterm ABOVE sea level is respected (floor = hterm = 800).
+    m._iceSIAFinalize(H_in.copy(), zbed, mdot0, 800.0, m.sia_slide, m.sia_glen)
+    H = m.iceHL.getArray()
+    assert (H[zbed < 800.0] == 0.0).all(), "prescribed terminus above sea level not honoured"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The glacier terminus clamp becomes `max(hterm, sea level)` instead of a fixed `hterm`:

- ice never persists below the (possibly time-varying) sea surface — no land ice offshore (there is no marine-ice/calving model);
- a prescribed `hterm` below sea level is raised to sea level;
- when `hterm` is omitted it defaults to the **sea-level position** (a sentinel), so the SIA dynamics + ablation set the actual terminus — instead of the previous fixed 1800 m default, which silently truncated ice above sea level.

Prescribed `hterm` above sea level is unchanged. Test `test_ice_terminus_sea_level_floor` covers all three cases. 38 passed, 1 skipped.