### PR TITLE
ice: catchment-aware glacial till routing (opt-in till.route)

### DIFF
--- a/docs/ICE_SHEET_SUMMARY.md
+++ b/docs/ICE_SHEET_SUMMARY.md
@@ -131,6 +131,7 @@ ice:
         l:  1.0           # sliding-velocity exponent
     till:
         on: True          # carry abraded rock as till / moraine
+        route: False      # True = route to termini (high-res); False = melt-spread
 ```
 
 `hela`/`hice`/`hterm` accept a uniform scalar (as above), a per-vertex map
@@ -170,10 +171,12 @@ Seven regression tests guard the model (`tests/test_regression.py`,
   polar) and through time — a single global scalar cannot represent both. The
   mass-balance ramp is evaluated per node with its local ELA. Uniform scalars
   and the `evol` CSV remain unchanged.
-- **Till routing.** Till is deposited across the ablation zone weighted by the
-  meltwater rate rather than routed per ice-catchment to each individual
-  terminus — a simplification matched to goSPL's resolution, where a cell
-  aggregates many glacial elements. The mass is conserved either way.
+- **Till routing.** By default till is deposited across the ablation zone
+  weighted by the meltwater rate — matched to coarse resolution where a cell
+  aggregates many glacial elements. For high-resolution (sub-km) regional runs,
+  `till.route: True` instead routes the till down the ice-surface flow network
+  and melts it out toward each catchment's terminus, building moraine at the
+  actual ice margins. Both conserve mass.
 - **Scalar SIA coefficients.** `Aglen` / `slide` are uniform (no spatial
   thermomechanical coupling). Spatially-variable softness/sliding would matter
   only for studies resolving thermal regime or till rheology, below the scope

--- a/docs/tech_guide/ice.rst
+++ b/docs/tech_guide/ice.rst
@@ -151,11 +151,26 @@ modes are used depending on whether stratigraphy is active:
   budget stays balanced. The bed bulks up by the porosity contrast between the
   uncompacted till and the compacted source rock.
 
-.. note::
+Independently of the bulk/stratigraphic split, the **deposition distribution**
+has two options. By default the till is spread across the ablation zone weighted
+by the local meltwater rate — adequate when a mesh cell aggregates a whole
+glacier (continental/global resolution). With ``till.route: True`` the till is
+instead **routed down the ice-surface flow network**: it is transported along
+steepest descent of the surface :math:`s = z_\mathrm{bed} + H` and melts out
+progressively toward each catchment's terminus, building moraine at the actual
+ice margins. This is a transport-with-loss solved with the same MPI-correct
+flow-matrix / KSP machinery as the river accumulation,
 
-   Till is deposited across the ablation zone weighted by the meltwater rate
-   rather than routed per ice-catchment to each individual terminus. Both modes
-   are protected by a dedicated mass-conservation test.
+.. math::
+   L_i = A_i + \sum_{u \to i} w_{ui}\,(1-f_u)\,L_u, \qquad D_i = f_i\,L_i,
+
+where :math:`A_i` is the local abraded volume, :math:`L_i` the till load passing
+through cell :math:`i`, and :math:`f_i = \min(1, \dot a_i \Delta t / H_i)` the
+melt-out fraction (forced to 1 at the ice margin so no till leaks onto bare
+ground). Routing is appropriate for high-resolution (sub-km) regional runs where
+individual glacier catchments and termini are resolved; at coarse resolution it
+reduces to near-local deposition. Both options conserve mass and are protected by
+dedicated tests.
 
 Ice loading and flexure
 -----------------------

--- a/docs/user_guide/surfproc.rst
+++ b/docs/user_guide/surfproc.rst
@@ -147,6 +147,7 @@ Ice sheets and glacial erosion
                     l: 1.0
                 till:
                     on: True
+                    route: False
 
         The equilibrium-line / ice-cap geometry controls where ice accumulates
         and melts:
@@ -175,6 +176,14 @@ Ice sheets and glacial erosion
            conserving the abraded volume. With stratigraphy on, the till is
            layered into the stratigraphic record and split into the coarse/fine
            lithology fractions when dual lithology is enabled.
+        j. ``route`` (default ``False``) — controls how the till is distributed.
+           ``False`` spreads it across the whole ablation zone weighted by the
+           meltwater rate (appropriate when a cell aggregates a glacier, i.e.
+           continental/global resolution). ``True`` instead **routes the till
+           down the ice-surface flow network** and melts it out toward each
+           catchment's terminus, building moraine at the actual ice margins — for
+           high-resolution (sub-km) regional runs where individual glacier
+           catchments and termini are resolved. Both conserve mass.
 
         The glacier geometry can instead be read from a file:
 

--- a/gospl/flow/iceplex.py
+++ b/gospl/flow/iceplex.py
@@ -8,6 +8,7 @@ from time import process_time
 if "READTHEDOCS" not in os.environ:
     from gospl._fortran import ice_flux
     from gospl._fortran import ice_velocity
+    from gospl._fortran import mfdreceivers
 
 # Ice density (kg/m^3), used for the SIA deformation coefficient and loading.
 RHO_ICE = 910.0
@@ -320,8 +321,15 @@ class IceMesh(object):
 
         Active only with ``till.on`` and ``Kg > 0``; a no-op otherwise.
 
-        Simplification (documented): till deposits across the ablation zone
-        weighted by melt rather than routed per ice-catchment to each terminus.
+        **Deposition distribution.** By default the till is spread across the
+        whole ablation zone weighted by the meltwater rate. With
+        ``till.route: True`` it is instead **routed down the ice-surface flow
+        network** and melts out toward each catchment's terminus
+        (:meth:`_routeTill`) — appropriate for high-resolution regional runs
+        where individual glacier catchments and termini are resolved. Both
+        produce a per-cell deposition weight (summing to one) consumed
+        identically by the bulk and stratigraphic paths, so conservation is
+        unchanged.
         """
         if not (self.iceOn and self.ice_till_on) or self.ice_Kg <= 0.0:
             return
@@ -334,12 +342,28 @@ class IceMesh(object):
         owned = self.inIDs == 1
         Vtot = MPI.COMM_WORLD.allreduce(float(np.sum(Vero[owned])), op=MPI.SUM)
 
-        melt = self.iceMeltL.getArray()                   # ablation water volume (m^3/yr)
-        Wtot = MPI.COMM_WORLD.allreduce(float(np.sum(melt[owned])), op=MPI.SUM)
+        # No abrasion -> nothing happens (skipping the erosion too keeps it
+        # conservative: no orphaned till).
+        if Vtot <= 0.0:
+            return
 
-        # No abrasion or no ablation zone to receive the till -> nothing happens
-        # (skipping the erosion too keeps it conservative: no orphaned till).
-        if Vtot <= 0.0 or Wtot <= 0.0:
+        # Per-cell deposition weight (local array, Σ over owned nodes = 1):
+        # melt-weighted spreading, or catchment-routed melt-out to the termini.
+        if self.ice_till_route:
+            dep_w = self._routeTill(Vero, Vtot, owned)
+        else:
+            melt = self.iceMeltL.getArray()               # ablation volume (m^3/yr)
+            Wtot = MPI.COMM_WORLD.allreduce(
+                float(np.sum(melt[owned])), op=MPI.SUM
+            )
+            # No ablation zone to receive the melt-spread till -> no-op.
+            if Wtot <= 0.0:
+                return
+            dep_w = melt / Wtot
+
+        # Routing can leave nothing depositable (e.g. no resolved outlet); guard.
+        Wdep = MPI.COMM_WORLD.allreduce(float(np.sum(dep_w[owned])), op=MPI.SUM)
+        if Wdep <= 0.0:
             return
 
         dz_ero = -Eg * self.dt                            # bed lowering (m, ≤0)
@@ -349,12 +373,11 @@ class IceMesh(object):
             # the abraded material leaves the layers it came from and the
             # moraine is recorded as a fresh deposit (split coarse/fine under
             # dual lithology). See _glacialTillStrata.
-            self._glacialTillStrata(dz_ero, melt, Wtot, owned)
+            self._glacialTillStrata(dz_ero, dep_w, owned)
         else:
-            # Bulk bed transport: erode at abrasion cells, deposit the till
-            # where ice melts, weighted by melt. Σ(dz·area) == 0 (rock moved,
-            # not created).
-            dz_dep = (Vtot * melt / Wtot) / self.larea
+            # Bulk bed transport: erode at abrasion cells, deposit the till per
+            # the deposition weight. Σ(dz·area) == 0 (rock moved, not created).
+            dz_dep = (Vtot * dep_w) / self.larea
             dz = dz_ero + dz_dep
             self.tmpL.setArray(dz)
             self.dm.localToGlobal(self.tmpL, self.tmp)
@@ -375,7 +398,7 @@ class IceMesh(object):
 
         return
 
-    def _glacialTillStrata(self, dz_ero, melt, Wtot, owned):
+    def _glacialTillStrata(self, dz_ero, dep_w, owned):
         r"""
         Stratigraphic / dual-lithology coupling for glacial till.
 
@@ -443,8 +466,8 @@ class IceMesh(object):
         # Ice-mixed till composition (single fine fraction for the moraine).
         ffrac = fineV / Vsolid if self.stratLith else 0.0
 
-        # --- Deposition: lay the till down in the ablation zone. ---
-        dz_dep = (Vsolid * melt / Wtot) / self.larea      # bulk till thickness (m)
+        # --- Deposition: lay the till down per the deposition weight. ---
+        dz_dep = (Vsolid * dep_w) / self.larea            # bulk till thickness (m)
         self.depoFineFrac = np.zeros(self.lpoints, dtype=np.float64)
         self.depoFineFrac[dz_dep > 0.0] = ffrac
         # Snapshot the current layer so the bed/cumED update uses the thickness
@@ -478,3 +501,103 @@ class IceMesh(object):
         self.depoFineFrac = saved_depoFineFrac
 
         return
+
+    def _routeTill(self, Vero, Vtot, owned):
+        r"""
+        Catchment-aware till routing on the ice-surface flow network
+        (``till.route: True``).
+
+        The abraded till is transported down the **ice surface**
+        :math:`s = z_\mathrm{bed} + H` along steepest descent (the same
+        direction the ice flux follows) and **melts out** progressively toward
+        each catchment's terminus, building moraine where the ice actually ends
+        rather than smearing it across the whole ablation zone. This matters at
+        high (sub-km) resolution where individual glacier catchments and termini
+        are resolved.
+
+        It is a transport-with-loss on the ice network, solved with the same
+        MPI-correct flow-matrix / KSP machinery as the river accumulation:
+
+        .. math::
+            L_i = A_i + \sum_{u \to i} w_{ui}\,(1 - f_u)\,L_u,
+            \qquad D_i = f_i\,L_i
+
+        where :math:`A_i` is the local abraded volume, :math:`L_i` the till
+        load passing through cell :math:`i`, and :math:`f_i \in [0,1]` the
+        melt-out fraction — the share of the local ice column lost to ablation
+        this step, :math:`f_i = \min(1, \dot{a}_i\,\Delta t / H_i)`. At the ice
+        margin (a cell whose steepest-descent receiver is ice-free) :math:`f`
+        is forced to 1 so no till leaks onto bare ground, which makes the
+        transport exactly conservative: :math:`\sum_i D_i = \sum_i A_i`.
+
+        :arg Vero: per-cell abraded volume (m^3, local array).
+        :arg Vtot: total abraded volume over owned nodes (m^3).
+        :arg owned: boolean mask of owned (non-ghost) nodes.
+
+        :return: per-cell deposition weight (local array, Σ over owned = 1).
+        """
+        # Halo-synced ice thickness and meltwater (ghost values are needed for
+        # the steepest-descent receivers and the melt-out fraction).
+        self.dm.localToGlobal(self.iceHL, self.tmp)
+        self.dm.globalToLocal(self.tmp, self.tmpL)
+        H = self.tmpL.getArray().copy()
+        self.dm.localToGlobal(self.iceMeltL, self.tmp)
+        self.dm.globalToLocal(self.tmp, self.tmpL)
+        melt = self.tmpL.getArray().copy()
+
+        zbed = self.hLocal.getArray()
+        s = zbed + H                                       # ice surface
+
+        # Steepest-descent (single-flow-direction) receivers on the ice surface.
+        rcv, _, wght = mfdreceivers(1, self.flowExp, s, self.sealevel, self.gid)
+        rcv0 = rcv[:, 0].astype(petsc4py.PETSc.IntType)
+        w0 = wght[:, 0].copy()
+
+        thr = 1.0e-2                                       # ice-presence threshold (m)
+        ice = H > thr
+        # Melt-out fraction f = (ablation thickness this step) / H, clamped.
+        meltThick = (melt * self.dt) / np.maximum(self.larea, 1.0e-12)
+        f = np.clip(meltThick / np.maximum(H, thr), 0.0, 1.0)
+        # Deposit fully (no downstream carry) off-ice and at the ice margin
+        # (receiver ice-free), so nothing leaks onto bare ground -> conservative.
+        f[~ice] = 1.0
+        f[ice & (H[rcv0] <= thr)] = 1.0
+
+        # Downstream-carried weight (1 - f); zero on ghosts/borders.
+        outw = w0 * (1.0 - f)
+        outw[self.ghostIDs] = 0.0
+        if self.flatModel:
+            outw[self.idBorders] = 0.0
+
+        # Accumulation matrix (I - W^T) on the ice network, then L = solve(·, A).
+        mat = self.iMat.copy()
+        indptr = np.arange(0, self.lpoints + 1, dtype=petsc4py.PETSc.IntType)
+        nodes = indptr[:-1]
+        data = -outw
+        data[rcv0 == nodes] = 0.0
+        tmpMat = self._matrix_build()
+        tmpMat.assemblyBegin()
+        tmpMat.setValuesLocalCSR(indptr, rcv0, data)
+        tmpMat.assemblyEnd()
+        mat.axpy(1.0, tmpMat)
+        tmpMat.destroy()
+        mat.transpose()
+
+        self.tmpL.setArray(Vero)
+        self.dm.localToGlobal(self.tmpL, self.tmp)
+        self._solve_KSP(True, mat, self.tmp, self.tmp1)
+        mat.destroy()
+        self.dm.globalToLocal(self.tmp1, self.tmpL)
+        L = self.tmpL.getArray().copy()
+
+        # Deposited volume per cell. The transport conserves analytically, but
+        # the KSP solve is only accurate to its tolerance, so normalise by the
+        # ACTUAL routed total (not Vtot) to make the weight sum to one exactly —
+        # mass conservation then matches the melt-weighted path bit-for-bit.
+        dep_vol = f * L
+        total = MPI.COMM_WORLD.allreduce(
+            float(np.sum(dep_vol[owned])), op=MPI.SUM
+        )
+        if total <= 0.0:
+            return np.zeros(self.lpoints, dtype=np.float64)
+        return dep_vol / total

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -1697,6 +1697,11 @@ class ReadYaml(object):
 
             tillDict = iceDict.get("till", {})
             self.ice_till_on = bool(tillDict.get("on", False))
+            # Catchment-aware till routing: when True, the abraded till is
+            # routed down the ice-surface flow network and melts out toward each
+            # terminus (for high-resolution regional runs); default False keeps
+            # the melt-weighted spreading across the whole ablation zone.
+            self.ice_till_route = bool(tillDict.get("route", False))
 
             # Use the per-vertex / time-series path when a `glaciers` series is
             # given or any top-level altitude is a map.
@@ -1729,6 +1734,7 @@ class ReadYaml(object):
             self.ice_Kg = 0.0
             self.ice_abr_l = 1.0
             self.ice_till_on = False
+            self.ice_till_route = False
 
         # Legacy uniform / `evol` path builds the scalar time functions. In
         # series mode the geometry comes from _iceTimeSeries via _updateIce, so

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -277,6 +277,7 @@ def test_ice_opt_in():
     assert p.iceOn is True
     assert p.sia_Aglen == 1.0e-16 and p.sia_glen == 3.0
     assert p.ice_Kg == 0.0 and p.ice_till_on is False
+    assert p.ice_till_route is False          # melt-weighted spreading by default
     # Terminus is unprescribed -> sentinel, resolved to the sea-level position
     # at runtime (so ice is not silently truncated above sea level).
     assert float(p.iceT(p.tStart)) < -1.0e9
@@ -289,13 +290,14 @@ def test_ice_opt_in():
             "hice": 2000.0,
             "sia": {"Aglen": 2.0e-16, "slide": 5.0e-3, "glen": 3.0},
             "abrasion": {"Kg": 1.0e-4, "l": 1.5},
-            "till": {"on": True},
+            "till": {"on": True, "route": True},
         }
     }
     p._readIce()
     assert p.iceOn is True
     assert p.sia_Aglen == 2.0e-16 and p.sia_slide == 5.0e-3 and p.sia_glen == 3.0
     assert p.ice_Kg == 1.0e-4 and p.ice_abr_l == 1.5
+    assert p.ice_till_route is True           # catchment routing opted in
     assert p.ice_till_on is True
 
 
@@ -567,6 +569,108 @@ def test_ice_glacial_till_conserves(minimal_ice_till_model):
     assert (dcum[zbed > 2500.0] <= 1.0e-9).all(), "no abrasion under fast ice"
     assert (dcum[(zbed > 1500.0) & (zbed < 2000.0)] >= -1.0e-9).all(), (
         "no till deposition in the ablation zone"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.slow
+def test_ice_till_routing(minimal_ice_sia_model):
+    """
+    Protects: catchment-aware till routing (iceplex._routeTill, `till.route`).
+    Abraded till is transported down the ice-surface flow network and melts out
+    toward the terminus, so (a) the deposition weight is conserved (Σ = 1), and
+    (b) with no ablation the melt-out fraction is zero at interior ice cells, so
+    they retain NO till — everything is carried downstream and deposited only at
+    the margin outlets (mesh-independent check of the transport mechanism).
+    """
+    from mpi4py import MPI
+    from gospl._fortran import mfdreceivers
+
+    m = minimal_ice_sia_model
+    zbed = m.hLocal.getArray().copy()
+    n = m.lpoints
+    owned = m.inIDs == 1
+
+    # Synthetic ice cap: thick interior thinning to a margin near 1500 m, so the
+    # ice surface s = zbed + H descends outward and routing funnels toward it.
+    H = np.clip(zbed - 1500.0, 0.0, 800.0)
+    m.iceHL.setArray(H)
+    m.iceMeltL.setArray(np.zeros(n))            # no melt -> pure routing to margin
+
+    if not (zbed > 2000.0).any():
+        pytest.skip("test mesh lacks the relief needed to exercise till routing")
+
+    # Abrasion source confined to the thick interior.
+    Vero = np.where(zbed > 2500.0, 1.0e6, 0.0)
+    Vtot = MPI.COMM_WORLD.allreduce(float(np.sum(Vero[owned])), op=MPI.SUM)
+    if Vtot <= 0.0:
+        pytest.skip("no abrasion source on this mesh")
+
+    dep_w = m._routeTill(Vero, Vtot, owned)
+
+    # (a) Mass conserved: the deposition weight sums to one over owned nodes.
+    wsum = MPI.COMM_WORLD.allreduce(float(np.sum(dep_w[owned])), op=MPI.SUM)
+    assert np.isclose(wsum, 1.0, rtol=1.0e-6), f"routed till not conserved (Σw={wsum})"
+    assert (dep_w >= -1.0e-12).all()
+
+    # (b) Interior ice cells (those whose steepest-descent receiver is also ice)
+    # have melt-out fraction 0 with no ablation, so they must retain no till —
+    # it is all carried downstream to the outlets.
+    rcv, _, _ = mfdreceivers(1, m.flowExp, zbed + H, m.sealevel, m.gid)
+    rcv0 = rcv[:, 0].astype(int)
+    ice = H > 1.0e-2
+    interior = owned & ice & (H[rcv0] > 1.0e-2)
+    if not interior.any():
+        pytest.skip("mesh too coarse: no multi-cell ice flow path to route along")
+    assert np.allclose(dep_w[interior], 0.0, atol=1.0e-12), (
+        "interior ice retained till despite routing (melt-out should carry it on)"
+    )
+    # And the till did land somewhere (at the outlets).
+    assert float(np.max(dep_w[owned])) > 0.0
+
+
+@pytest.mark.slow
+def test_ice_till_routing_conserves(minimal_ice_sia_model):
+    """
+    Protects: glacialTill with `till.route` is mass-conserving end-to-end (bulk
+    bed mode) — abraded rock routed down-ice and deposited at the termini leaves
+    the net bed-volume change zero (eroded == deposited).
+    """
+    from mpi4py import MPI
+    m = minimal_ice_sia_model
+    m.ice_till_on = True
+    m.ice_till_route = True
+    m.ice_Kg = 1.0e-3
+    m.ice_abr_l = 1.0
+    n = m.lpoints
+    owned = m.inIDs == 1
+    larea = m.larea
+
+    zbed = m.hLocal.getArray().copy()
+    m.iceHL.setArray(np.clip(zbed - 1500.0, 0.0, 800.0))
+    m.iceUbL.setArray(np.where(zbed > 2500.0, 0.1, 0.0))   # sliding interior
+    m.iceMeltL.setArray(np.zeros(n))
+    if not (zbed > 2500.0).any():
+        pytest.skip("test mesh lacks the relief to exercise till routing")
+
+    cum0 = m.cumEDLocal.getArray().copy()
+    m._tillEroded = 0.0
+    m._tillDeposited = 0.0
+    m.glacialTill()
+
+    ero = MPI.COMM_WORLD.allreduce(m._tillEroded, op=MPI.SUM)
+    dep = MPI.COMM_WORLD.allreduce(m._tillDeposited, op=MPI.SUM)
+    assert ero > 0.0, "no till produced; test is vacuous"
+    assert np.isclose(ero, dep, rtol=1.0e-9), "routed till eroded != deposited"
+
+    # Net bed-volume change is negligible relative to the till volume moved
+    # (erosion balanced by deposition). Measured against `ero` rather than the
+    # bed "activity", which collapses to ~0 on a coarse mesh where the abraded
+    # cell is its own outlet (till deposited where it was eroded).
+    dcum = m.cumEDLocal.getArray() - cum0
+    netvol = MPI.COMM_WORLD.allreduce(float(np.sum((dcum * larea)[owned])), op=MPI.SUM)
+    assert abs(netvol) < 1.0e-6 * ero, (
+        f"routed till not volume-conserving: net={netvol:.3e} eroded={ero:.3e}"
     )
 
 


### PR DESCRIPTION
For high-resolution regional runs (sub-km), `ice.till.route: True` routes the abraded till **down the ice-surface flow network** and melts it out toward each catchment's terminus — building moraine at the actual ice margins, rather than the default melt-weighted spreading across the whole ablation zone.

**`_routeTill`** is a transport-with-loss on the ice surface `s = zbed + H`: steepest-descent receivers, a melt-out fraction `f = min(1, ablation·dt/H)` (forced to 1 at the margin so no till leaks onto bare ground), solved as `L = A + Wᵀ(1−f)L` with goSPL's existing MPI-correct flow-matrix/KSP machinery; deposition `D = f·L`. The weight is normalised to sum to one exactly, so conservation matches the melt-weighted path bit-for-bit.

`glacialTill` / `_glacialTillStrata` refactored to consume a pluggable per-cell deposition weight — bulk and stratigraphic/dual-lithology paths otherwise unchanged. Default (`route: False`) behaviour is identical to before.

When to use: routing matters once cell size < glacier catchment length (sub-km regional/alpine domains); at coarse global resolution it reduces to near-local deposition. Both options conserve mass.

Tests: `test_ice_till_routing` (conservation + mesh-independent melt-out check) and `test_ice_till_routing_conserves` (end-to-end bulk conservation). 40 passed, 1 skipped.