### PR TITLE
analyse: sediment-provenance / source-to-sink attribution tool (prototype)

### DIFF
--- a/docs/DESIGN_PROVENANCE.md
+++ b/docs/DESIGN_PROVENANCE.md
@@ -1,0 +1,190 @@
+# DESIGN — sediment provenance & source-to-sink attribution (Cu prospectivity)
+
+Status: design + prototype (`gospl/analyse/provenance.py`). Standalone analysis on
+goSPL output; an in-model high-fidelity variant is scoped in §6.
+
+## 1. Problem
+
+Given **source-rock polygons** (user shapefiles, each tagged with a rock type)
+and **sink-basin polygons**, quantify — from a goSPL run — how much of the
+sediment deposited in each sink derives from each source rock type, and where:
+
+1. **per sink basin** — the % contribution of each source class;
+2. **per pixel** (mesh node) in the basin — the source-mixture composition;
+
+plus routing diagnostics (transport distance, erosion/deposition pathways) and a
+**copper-prospectivity layer** weighting source classes by Cu fertility.
+
+This is a *sediment-provenance* (source-to-sink attribution) problem layered on
+goSPL's mass-conserving erosion/transport/deposition.
+
+## 2. What goSPL provides
+
+Per output step (`tout`) the mesh HDF5 holds: `coords`/`cells` (mesh), `elev`,
+`erodep` (cumulative ED) and `EDrate`, `FA`, `fillFA`, `waterFill`,
+`sedLoad`/`sedLoadF` (total + fine flux), and the stratigraphy
+(`stratH`/`stratHf`/`phiS`/`phiF`/`stratK`/`stratZ`). Flow **directions are not
+saved**, so the tool re-derives the routing network from the filled elevation
+(`fillFA`/`elev`) + the mesh connectivity each step.
+
+**Partitioned output.** goSPL writes one HDF5 per MPI partition per step
+(`<base>.<step>.p<rank>.h5`, float32 datasets; partition meshes in
+`topology.p<rank>.h5`), each holding only that rank's local nodes. Provenance
+routing is global, so the tool (`GosplOutput`) reassembles each field onto the
+**global input-mesh** ordering by mapping every partition's local coordinates to
+the global vertices with a KDTree — the same local↔global map goSPL builds at
+load (`tree.query(lcoords)`). Per-vertex `source_class`/`basin_id` are supplied
+in that global ordering; shared ghost nodes carry agreeing (post-halo-sync)
+values so the scatter is idempotent.
+
+## 3. Two architectures
+
+### A. Standalone particle/fraction tracking (this design + prototype)
+Post-process the saved output: assign each mesh vertex a source class (from the
+polygons), re-derive the per-step flow network, route the eroded material
+downstream, and accumulate the deposited provenance per node/basin. No re-run
+needed; flexible; gives distances and pathways. Approximate: it sees **net**
+`erodep` per *output* step (not the compute `dt`), re-derives routing, and is
+statistical/heuristic in its deposition rule.
+
+### B. In-model provenance tracers (high fidelity — scoped §6)
+Generalise the dual-lithology machinery (which already routes a *second* exact
+sub-flux `vSedF` and stores per-layer composition `stratHf`) from 2 fractions to
+**N source-provenance fractions**. Exact, mass-conserving, recycling-aware;
+requires re-running with tracers on. Reuses proven code.
+
+They are complementary: **A** for exploration on existing runs, **B** when
+defensible percentages are needed.
+
+## 4. Standalone tool — data model & algorithm
+
+### Inputs
+
+All per-vertex arrays are in the **global input-mesh** ordering (`npdata` mesh
+`v`); build the labels with `classes_from_shapefile` and reassemble model fields
+with `GosplOutput`.
+
+| input | shape | required | meaning / how to obtain |
+|---|---|---|---|
+| mesh `coords` (`v`) | (N, 2\|3) | **yes** | global vertex coordinates; defines ordering + geometry |
+| mesh `cells` (`c`) | (M, 3) | **yes\*** | triangular cells → adjacency (\*or pass a prebuilt `neighbours`) |
+| `source_class` | (N,) int | **yes** | source-rock class per vertex, in `[0, n_classes)` — point-in-polygon of the source shapefiles; vertices outside every polygon get a **background/"other"** class (not −1) |
+| `n_classes` | scalar | **yes** | number of source classes |
+| goSPL output series | per step | **yes** | `elev` (routing surface) + `erodep`, fed to `step()` via `GosplOutput` |
+| `area` | (N,) | no | Voronoi cell area (m²); default 1. Provide for correct volumes on irregular meshes (percentages are area-independent) |
+| `basin_id` | (N,) int | **no** | sink-basin label per vertex, −1 = not a sink. Needed **only** for the per-basin % roll-up (`basin_percentages`); per-pixel provenance is produced everywhere without it. Build with `classes_from_shapefile(..., background=None)` |
+| `cu_weight` | (C,) | no | copper fertility per source class; needed only for `cu_fraction` |
+
+`source_class` is validated on construction (must be a full per-vertex array
+with values in `[0, n_classes)`), so a mis-sized or −1-containing array fails
+fast with a clear message rather than silently mis-attributing.
+
+### State (carried across steps)
+- `pile[node, class]` — provenance composition (m³ per class) of the
+  *deposited* material currently stored at each node. Enables **recycling**:
+  re-eroded sediment carries the pile's mixed provenance, fresh bedrock carries
+  the node's `source_class`.
+- `dep[node, class]` — cumulative deposited volume per class (the answer).
+- `dist[node]` — flux-weighted mean source→deposition transport distance.
+
+### Per output step (Δerodep = erodep(t) − erodep(t−1))
+1. **Erode** at nodes with Δerodep < 0: eroded volume `E = −Δerodep·area`. Its
+   provenance = the local `pile` composition for the pile portion (recycling),
+   `source_class` (bedrock) for the remainder; decrement `pile`.
+2. **Route** — build the downhill-flow graph from the filled elevation and sweep
+   nodes high→low, pushing the per-class eroded flux to each node's
+   receiver(s) (the deterministic continuum of particle advection — no
+   Monte-Carlo noise). Routing is **multiple-flow-direction by default** (flux
+   splits across all lower neighbours by slope^`flow_exp`, so a source can feed
+   several basins partially — the realistic choice for provenance), with single
+   steepest descent available (`routing='sfd'`). Carry a distance accumulator
+   along the path (split with the flux under MFD).
+3. **Deposit** at nodes with Δerodep > 0: capture `D = Δerodep·area` from the
+   passing flux with the flux's current composition; add to `pile` and `dep`.
+   Flux entering a sink basin / the sea settles there.
+
+Conservation holds within a step by construction (eroded = deposited + outflow).
+
+### Outputs
+- **per basin**: `Σ dep[node∈basin, class]` normalised → % per source rock type.
+- **per pixel**: `dep[node, :]` normalised → composition map (dominant source or
+  full vector), rasterisable.
+- **diagnostics**: mean transport distance per source→sink pair; pathway maps.
+- **Cu layer**: `Σ_class cu_weight[class]·dep[node, class] / Σ dep` → Cu-sourced
+  fraction per pixel/basin.
+
+### Output format (saved per time step)
+Results are written **per output step** so the provenance evolution is preserved
+and can be viewed in ParaView alongside the goSPL output:
+- a single **HDF5** `<prefix>.h5` with `/mesh/{coords,cells}`, `/steps`, and a
+  `/step_<s>/` group per step holding `fractions` (npoints × n_classes),
+  `dominant` (argmax class), `distance`, and `cu_fraction` (float32, gzipped,
+  written incrementally so the full series is never held in memory);
+- a **per-basin time-series CSV** (`<prefix>_basins.csv`: `step, basin,
+  class0%, …`).
+An XDMF temporal wrapper (so the HDF5 overlays the model output through time) is
+a P1 add-on.
+
+### Performance
+The per-step **flow-graph build** (`downhill_edges`) is fully vectorised in NumPy
+(edge slopes/weights via CSR run-length + `bincount`/`lexsort`). The downstream
+**accumulation sweep** is inherently sequential (topological order, each node
+depends on its donors) — O(N+E) per step in Python, the bottleneck for large
+meshes. Production speed-ups (not in the prototype): a `numba`-JIT sweep, or
+recast the deposition as the **sparse transport-with-loss solve**
+`(I − Wᵀ diag(1−f)) L_c = A_c` per class (the same linear form as the SIA till
+routing), factorising once per step and solving the N_class right-hand sides in
+compiled sparse code.
+
+## 5. Copper prospectivity — scope boundary
+
+The tool delivers the **physical provenance and routing** of detritus (which
+source, how far, deposited where) — a necessary input to detrital/placer and
+sediment-hosted Cu reasoning, **not** an ore-forming model. Real favourability
+also needs hydrodynamic concentration (placers: heavy-mineral sorting by
+energy/grain size — couple to the dual-lithology coarse/fine split) and, for
+sediment-hosted Cu, facies/redox/diagenesis. Output is framed as a
+*provenance-and-fertility proxy* (Cu-fertile detritus flux and accumulation),
+explicitly upstream of the metallogenic step. The strongest favourability layer
+combines **provenance × grain size × depositional setting**.
+
+## 6. In-model provenance tracers (Approach B) — scope
+
+Generalise dual lithology (`docs/DESIGN_DUAL_LITHOLOGY.md`) to N provenance
+classes:
+- **State**: `stratP[node, layer, class]` per-layer provenance fractions
+  (mirrors `stratHf`); `provFrac[node, class]` of the routed flux (mirrors
+  `fineFrac`).
+- **Erosion**: split eroded solid by the consumed layers' provenance (mirrors
+  `erodeStrat`'s fine split), bedrock contributing its `source_class`.
+- **Transport**: route each class sub-flux through the same flow operator as the
+  total (linear, exact) — N extra `_solve_KSP` solves (or one block solve);
+  reuse `_getSedFlux`/`_moveDownstream` threading like `vSedF`.
+- **Deposition**: deposit with the flux composition; write `stratP`.
+- **Conservation**: per-class guard (the analogue of `test_dual_fine_conservation`).
+- **Cost/scope**: N is user-set (a handful of source provinces). Heaviest part is
+  N sub-fluxes per step; acceptable for the target use. Output `stratP` →
+  provenance % per pixel/basin directly, recycling-aware, exact.
+
+Deliver B opt-in (`provenance:` YAML block), inert when absent (byte-identical),
+mirroring the dual-lithology delivery discipline.
+
+## 7. Phasing
+
+- **P0** — standalone core (this prototype): neighbour build, per-step receiver
+  re-derivation, fraction-routing provenance with recycling, per-basin % +
+  per-pixel composition + distance + Cu layer. Synthetic-mesh tests.
+- **P1** — I/O: read goSPL HDF5 series; shapefile → `source_class`/`basin_id`
+  (lazy `geopandas`); raster/CSV/plot export.
+- **P2** — discrete-particle mode for full path-length *distributions* (the
+  fraction router gives means); pathway visualisation.
+- **P3** — Approach B in-model tracers (§6) for conservation-exact provenance.
+- **P4** — Cu favourability: combine provenance × dual-lithology grain size ×
+  depositional energy.
+
+## 8. Caveats (carried into the docs)
+
+- Output cadence, not compute `dt`: sub-step erode→redeposit is invisible to A.
+- Routing is reconstructed from saved filled elevation, not goSPL's live network.
+- A is statistical/heuristic (exact volumes ⇒ B); good for % and pathways.
+- Provenance ≠ prospectivity (§5).

--- a/gospl/analyse/__init__.py
+++ b/gospl/analyse/__init__.py
@@ -1,0 +1,15 @@
+"""
+goSPL analysis tools (post-processing of model output).
+
+Currently provides :mod:`gospl.analyse.provenance` — sediment source-to-sink
+provenance attribution and a copper-fertility layer. See
+``docs/DESIGN_PROVENANCE.md``.
+"""
+
+from .provenance import (  # noqa: F401
+    GosplOutput,
+    ProvenanceTracker,
+    build_neighbours,
+    downhill_edges,
+    steepest_receivers,
+)

--- a/gospl/analyse/provenance.py
+++ b/gospl/analyse/provenance.py
@@ -1,0 +1,607 @@
+"""
+Sediment provenance / source-to-sink attribution from goSPL output.
+
+Standalone post-processor (Approach A in ``docs/DESIGN_PROVENANCE.md``): given a
+per-vertex **source class** (from user source-rock polygons) and a goSPL run, it
+tracks the eroded material down the per-step flow network and accumulates, in
+each sink, the deposited volume attributable to each source rock type — per
+basin and per pixel (mesh node) — plus the mean transport distance and an
+optional copper-fertility layer.
+
+The core (:class:`ProvenanceTracker`) is pure NumPy and operates on arrays, so it
+runs without GIS / HDF5 dependencies; the optional I/O helpers
+(:func:`classes_from_shapefile`, :func:`tracker_from_gospl`) import ``geopandas``
+/ ``h5py`` lazily.
+
+Method (deterministic continuum of particle tracking, mass-conserving per step):
+for each output step the net ``erodep`` change gives the eroded volume (sources)
+and deposited volume (sinks); the eroded material — recycled from the local
+deposited pile, plus fresh bedrock of the node's source class — is routed
+downstream and laid down where the model deposits, carrying its provenance and
+travelled distance. Routing is **multiple-flow-direction** by default (flux
+splits across all lower neighbours by slope, so a source can feed several
+basins), with single steepest descent available (``routing='sfd'``).
+
+Caveats (see the design doc): it sees the **net** erodep per *output* step (not
+the compute dt), re-derives the routing from the saved elevation, and is a
+reconstruction — exact volumes need the in-model tracer (Approach B). Provenance
+is not prospectivity: the Cu layer is a fertility-weighted detritus proxy,
+upstream of the ore-forming process.
+
+Inputs (all per-vertex arrays are in the **global input-mesh** ordering — the
+``npdata`` mesh ``v``; build per-vertex labels with
+:func:`classes_from_shapefile` and reassemble model fields with
+:class:`GosplOutput`):
+
+==================  ========  ========  ===================================================
+input               shape     required  meaning / how to obtain
+==================  ========  ========  ===================================================
+``coords``          (N, 2|3)  yes       global mesh vertex coordinates (mesh ``v``)
+``cells``           (M, 3)    yes*      triangular cells (mesh ``c``); *or* pass ``neighbours``
+``source_class``    (N,)      yes       integer source-rock class per vertex, in
+                                        ``[0, n_classes)`` — point-in-polygon of the source
+                                        shapefiles (assign an "other"/background class to
+                                        vertices outside every polygon; do **not** use -1)
+``n_classes``       scalar    yes       number of source classes
+``erodep``/``elev`` (N,)      yes       per step, fed to :meth:`step` (from ``GosplOutput``)
+``area``            (N,)      no        Voronoi cell area (m²); defaults to 1. Provide it for
+                                        correct volumes on irregular meshes (ratios/%, which
+                                        are area-independent, are unaffected)
+``basin_id``        (N,)      no        sink-basin label per vertex, ``-1`` = not in a sink.
+                                        **Optional** — needed *only* for the per-basin %
+                                        roll-up (:meth:`basin_percentages`); per-pixel
+                                        provenance is produced everywhere regardless
+``cu_weight``       (C,)      no        copper fertility per source class; needed only for
+                                        :meth:`cu_fraction`
+==================  ========  ========  ===================================================
+"""
+
+import numpy as np
+
+
+def build_neighbours(cells, npoints):
+    """
+    Build the vertex adjacency (CSR ``indptr``/``indices``) from triangular mesh
+    cells — the undirected edge graph used for steepest-descent routing.
+
+    :arg cells: (ntri, 3) integer vertex indices.
+    :arg npoints: number of vertices.
+    :return: (indptr, indices) CSR adjacency arrays.
+    """
+    cells = np.asarray(cells)
+    e = np.vstack(
+        [cells[:, [0, 1]], cells[:, [1, 2]], cells[:, [2, 0]]]
+    )
+    e = np.vstack([e, e[:, ::-1]])                       # undirected
+    e = np.unique(e, axis=0)
+    counts = np.bincount(e[:, 0], minlength=npoints)
+    indptr = np.zeros(npoints + 1, dtype=np.int64)
+    indptr[1:] = np.cumsum(counts)
+    indices = e[:, 1].astype(np.int64)                   # e sorted by col 0 via unique
+    return indptr, indices
+
+
+def steepest_receivers(elev, indptr, indices):
+    """
+    Single-flow-direction (SFD) receivers: each node points to its lowest
+    neighbour strictly below it, or to itself (a sink / outlet) if none is lower.
+
+    :return: integer receiver array (length npoints).
+    """
+    n = len(elev)
+    rcv = np.arange(n, dtype=np.int64)
+    for i in range(n):
+        lo = elev[i]
+        best = i
+        for k in range(indptr[i], indptr[i + 1]):
+            j = indices[k]
+            if elev[j] < lo:
+                lo = elev[j]
+                best = j
+        rcv[i] = best
+    return rcv
+
+
+def downhill_edges(elev, coords, indptr, indices, routing="mfd", exponent=1.0):
+    """
+    Build the weighted downhill-flow graph as CSR edges
+    ``(e_indptr, e_idx, e_weight, e_seg)``: for each node, the receivers it
+    routes to, the fraction of its flux each takes, and the edge length.
+
+    - ``routing='sfd'``: a single edge to the steepest-descent neighbour
+      (weight 1); empty for sinks/outlets.
+    - ``routing='mfd'``: an edge to **every** lower neighbour, weight
+      :math:`\\propto \\text{slope}^{exponent}` and normalised to sum to one
+      (multiple-flow-direction, as goSPL routes water/sediment). ``exponent``
+      is the flow-partition exponent (1 ≈ uniform-to-slope spreading).
+    """
+    n = len(elev)
+    elev = np.asarray(elev, dtype=np.float64)
+    coords = np.asarray(coords, dtype=np.float64)
+    # All adjacency edges as (src -> dst), vectorised (indices is CSR-grouped by
+    # source, so `src` is the run-length expansion of the node ids).
+    src = np.repeat(np.arange(n), np.diff(indptr))
+    dst = indices
+    dz = elev[src] - elev[dst]
+    down = dz > 0.0                                    # keep downhill edges only
+    src, dst, dz = src[down], dst[down], dz[down]
+    seg = np.linalg.norm(coords[dst] - coords[src], axis=1)
+    slope = np.divide(dz, seg, out=dz.copy(), where=seg > 0.0)
+    w = slope ** exponent
+
+    if routing == "sfd":
+        # One edge per source: the steepest. Edges are grouped by source; pick
+        # the max-slope edge in each group.
+        order = np.lexsort((-slope, src))
+        s_o = src[order]
+        first = np.empty(len(s_o), dtype=bool)
+        first[0] = True if len(s_o) else False
+        first[1:] = s_o[1:] != s_o[:-1]
+        keep = order[first]
+        e_src, e_idx, e_seg = src[keep], dst[keep], seg[keep]
+        e_w = np.ones(len(keep))
+    else:
+        # MFD: normalise weights per source to sum to one.
+        wsum = np.bincount(src, weights=w, minlength=n)
+        e_src, e_idx, e_seg = src, dst, seg
+        e_w = w / wsum[src]
+
+    # CSR indptr from per-source edge counts (edges stay grouped by source).
+    counts = np.bincount(e_src, minlength=n)
+    e_indptr = np.zeros(n + 1, dtype=np.int64)
+    e_indptr[1:] = np.cumsum(counts)
+    return (
+        e_indptr,
+        np.asarray(e_idx, dtype=np.int64),
+        np.asarray(e_w, dtype=np.float64),
+        np.asarray(e_seg, dtype=np.float64),
+    )
+
+
+class ProvenanceTracker:
+    """
+    Accumulate source-to-sink sediment provenance over a goSPL run.
+
+    Feed cumulative ``erodep`` snapshots in time order with :meth:`step`; read
+    the attribution with :meth:`basin_percentages`, :meth:`pixel_fractions`,
+    :meth:`mean_distance` and :meth:`cu_fraction`.
+    """
+
+    def __init__(
+        self,
+        coords,
+        source_class,
+        n_classes,
+        area=None,
+        cells=None,
+        neighbours=None,
+        basin_id=None,
+        cu_weight=None,
+        routing="mfd",
+        flow_exp=1.0,
+    ):
+        """
+        **Required**
+
+        :arg coords: (npoints, 2|3) global-mesh vertex coordinates (mesh ``v``);
+            used for travel distance and to define the vertex ordering all the
+            other per-vertex arrays must follow.
+        :arg source_class: (npoints,) integer source-rock class per vertex, each
+            value in ``[0, n_classes)``. Obtain by point-in-polygon of the source
+            shapefiles (:func:`classes_from_shapefile`); give vertices outside
+            every polygon a dedicated "other"/background class — **not** -1.
+        :arg n_classes: number of source classes.
+
+        **One of** ``cells`` / ``neighbours`` (the routing connectivity)
+
+        :arg cells: (ntri, 3) triangular mesh cells (mesh ``c``) — adjacency is
+            built from these.
+        :arg neighbours: pre-built ``(indptr, indices)`` CSR adjacency (instead
+            of ``cells``).
+
+        **Optional**
+
+        :arg area: (npoints,) Voronoi cell area (m²); defaults to 1 (volume ==
+            thickness). Provide it for correct volumes on irregular meshes;
+            percentages/ratios are area-independent and unaffected.
+        :arg basin_id: (npoints,) sink-basin label per vertex, ``-1`` = not in a
+            sink basin. **Optional** — needed *only* for :meth:`basin_percentages`
+            (the per-basin roll-up). Per-pixel provenance (:meth:`pixel_fractions`)
+            is produced at every depositing node regardless.
+        :arg cu_weight: (n_classes,) copper fertility per source class; needed
+            only for :meth:`cu_fraction`.
+        :arg routing: ``'mfd'`` (default, multiple-flow-direction — flux splits
+            across all lower neighbours by slope, so a source can feed several
+            basins) or ``'sfd'`` (single steepest descent).
+        :arg flow_exp: MFD flow-partition exponent (slope power for the weights).
+        """
+        self.coords = np.asarray(coords, dtype=np.float64)
+        self.npoints = self.coords.shape[0]
+        self.source_class = np.asarray(source_class, dtype=np.int64)
+        self.n_classes = int(n_classes)
+        if self.source_class.shape != (self.npoints,):
+            raise ValueError(
+                "source_class must have one value per vertex (%d), got %s"
+                % (self.npoints, self.source_class.shape)
+            )
+        if self.source_class.min() < 0 or self.source_class.max() >= self.n_classes:
+            raise ValueError(
+                "source_class values must lie in [0, n_classes); assign a "
+                "background/'other' class to vertices outside every source "
+                "polygon (do not use -1)."
+            )
+        self.area = (
+            np.ones(self.npoints) if area is None else np.asarray(area, dtype=np.float64)
+        )
+        if neighbours is not None:
+            self.indptr, self.indices = neighbours
+        elif cells is not None:
+            self.indptr, self.indices = build_neighbours(cells, self.npoints)
+        else:
+            raise ValueError("provide either `cells` or `neighbours`")
+        self.basin_id = None if basin_id is None else np.asarray(basin_id, dtype=np.int64)
+        self.cu_weight = None if cu_weight is None else np.asarray(cu_weight, dtype=np.float64)
+        if routing not in ("mfd", "sfd"):
+            raise ValueError("routing must be 'mfd' or 'sfd'")
+        self.routing = routing
+        self.flow_exp = float(flow_exp)
+
+        # State.
+        self.pile = np.zeros((self.npoints, self.n_classes))     # stored deposit comp.
+        self.dep = np.zeros((self.npoints, self.n_classes))      # cumulative deposited
+        self._dep_dist = np.zeros(self.npoints)                  # Σ dist·vol deposited
+        self._dep_vol = np.zeros(self.npoints)                   # Σ vol deposited
+        self.exported = np.zeros(self.n_classes)                 # left via outlets
+        self._erodep_prev = None
+
+    def step(self, elev, erodep):
+        """
+        Process one output step.
+
+        :arg elev: (npoints,) surface elevation at this step (filled elevation
+            preferred — ``fillFA``'s surface — so routing has no spurious pits).
+        :arg erodep: (npoints,) cumulative erosion-deposition at this step.
+        """
+        erodep = np.asarray(erodep, dtype=np.float64)
+        if self._erodep_prev is None:
+            self._erodep_prev = erodep.copy()
+            return
+        vol = (erodep - self._erodep_prev) * self.area          # +dep / -ero (m^3)
+        self._erodep_prev = erodep.copy()
+
+        # 1. Erosion sources: recycle the local pile first, then fresh bedrock.
+        E = np.maximum(-vol, 0.0)
+        pile_tot = self.pile.sum(axis=1)
+        take = np.minimum(E, pile_tot)
+        rfrac = np.divide(take, pile_tot, out=np.zeros_like(take), where=pile_tot > 0)
+        recycled = self.pile * rfrac[:, None]
+        self.pile -= recycled
+        eroded = recycled
+        bed = E - take
+        np.add.at(eroded, (np.arange(self.npoints), self.source_class), bed)
+
+        # 2. Route downstream (high -> low) and 3. deposit where the model does.
+        elev = np.asarray(elev, dtype=np.float64)
+        e_indptr, e_idx, e_w, e_seg = downhill_edges(
+            elev, self.coords, self.indptr, self.indices, self.routing, self.flow_exp
+        )
+        order = np.argsort(elev)[::-1]
+        D = np.maximum(vol, 0.0)                                 # deposition (m^3)
+        flux = eroded.copy()                                    # per-class vol at node
+        flux_dist = np.zeros(self.npoints)                      # Σ vol·distance carried
+
+        for i in order:
+            tot = flux[i].sum()
+            if tot <= 0.0:
+                continue
+            comp = flux[i] / tot
+            # Deposit the model's deposition volume here, with the flux comp.
+            d = min(D[i], tot)
+            if d > 0.0:
+                self.dep[i] += comp * d
+                self.pile[i] += comp * d
+                mean_here = flux_dist[i] / tot
+                self._dep_dist[i] += mean_here * d
+                self._dep_vol[i] += d
+                flux[i] -= comp * d
+                flux_dist[i] -= mean_here * d
+                tot -= d
+            a, b = e_indptr[i], e_indptr[i + 1]
+            if a == b:
+                # Outlet / sink: the remainder leaves the routed system here
+                # (e.g. the domain edge or the open ocean).
+                if tot > 0.0:
+                    self.exported += flux[i]
+                continue
+            # Split the remaining flux across the downhill receivers by weight;
+            # each carries its share of the accumulated travel distance + the
+            # edge length (MFD spreads a source over several paths/basins).
+            fd_i = flux_dist[i]
+            for k in range(a, b):
+                j, w, seg = e_idx[k], e_w[k], e_seg[k]
+                flux[j] += w * flux[i]
+                flux_dist[j] += w * (fd_i + tot * seg)
+            flux[i] = 0.0
+            flux_dist[i] = 0.0
+
+    # ----- results -----
+
+    def pixel_fractions(self):
+        """Per-node deposited provenance fractions (npoints, n_classes); rows
+        that received no deposit are all-zero."""
+        tot = self.dep.sum(axis=1, keepdims=True)
+        return np.divide(self.dep, tot, out=np.zeros_like(self.dep), where=tot > 0)
+
+    def mean_distance(self):
+        """Per-node flux-weighted mean source->deposition transport distance."""
+        return np.divide(
+            self._dep_dist, self._dep_vol,
+            out=np.full(self.npoints, np.nan), where=self._dep_vol > 0,
+        )
+
+    def basin_percentages(self):
+        """
+        Dict ``{basin_id: array(n_classes)}`` of the % contribution of each
+        source class to each sink basin. Requires ``basin_id``.
+        """
+        if self.basin_id is None:
+            raise ValueError("basin_id was not provided")
+        out = {}
+        for b in np.unique(self.basin_id):
+            if b < 0:
+                continue
+            v = self.dep[self.basin_id == b].sum(axis=0)
+            s = v.sum()
+            out[int(b)] = (100.0 * v / s) if s > 0 else np.zeros(self.n_classes)
+        return out
+
+    def cu_fraction(self):
+        """Per-node Cu-sourced fraction of the deposit (needs ``cu_weight``)."""
+        if self.cu_weight is None:
+            raise ValueError("cu_weight was not provided")
+        tot = self.dep.sum(axis=1)
+        cu = self.dep @ self.cu_weight
+        return np.divide(cu, tot, out=np.zeros_like(cu), where=tot > 0)
+
+
+# --------------------------------------------------------------------------- #
+# Optional I/O (lazy GIS / HDF5 imports)
+# --------------------------------------------------------------------------- #
+
+def classes_from_shapefile(
+    coords, shapefile, attribute, background="other", crs=None
+):
+    """
+    Assign each vertex an integer class by point-in-polygon against a source-rock
+    (or sink-basin) polygon shapefile. The result is directly usable as the
+    tracker's ``source_class``: every vertex gets a class in ``[0, n_classes)``,
+    with vertices outside every polygon assigned a **background class** (so there
+    are no ``-1`` sentinels). Lazily imports ``geopandas``/``shapely``.
+
+    :arg coords: (npoints, 2|3) vertex coordinates in the shapefile's CRS
+        (only the first two columns are used).
+    :arg shapefile: path to a polygon shapefile.
+    :arg attribute: polygon attribute holding the class label.
+    :arg background: label for vertices outside every polygon (appended as its
+        own class). Set to ``None`` to instead return ``-1`` for those vertices
+        (e.g. when building a ``basin_id``, where -1 means "not a sink").
+    :arg crs: optional CRS to reproject the polygons to before testing.
+    :return: ``(class_array, {label: int} mapping)``. For ``source_class`` use
+        the array as-is; for ``basin_id`` pass ``background=None``.
+    """
+    try:
+        import geopandas as gpd
+        from shapely.geometry import Point
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "classes_from_shapefile needs geopandas + shapely "
+            "(`pip install geopandas`)"
+        ) from exc
+
+    gdf = gpd.read_file(shapefile)
+    if crs is not None:
+        gdf = gdf.to_crs(crs)
+    pts = gpd.GeoDataFrame(
+        geometry=[Point(xy) for xy in coords[:, :2]], crs=gdf.crs
+    )
+    joined = gpd.sjoin(pts, gdf[[attribute, "geometry"]], how="left", predicate="within")
+    joined = joined[~joined.index.duplicated(keep="first")]
+    labels = joined[attribute].to_numpy()
+    uniq = [u for u in np.unique(labels[~_isnull(labels)])]
+    mapping = {u: i for i, u in enumerate(uniq)}
+    out = np.full(len(coords), -1, dtype=np.int64)
+    for i, lab in enumerate(labels):
+        if not _isnull(lab):
+            out[i] = mapping[lab]
+    if background is not None and (out < 0).any():
+        bg = len(mapping)
+        mapping[background] = bg
+        out[out < 0] = bg
+    return out, mapping
+
+
+def _isnull(v):
+    try:
+        return bool(np.isnan(v))
+    except (TypeError, ValueError):
+        return v is None
+
+
+class GosplOutput:
+    """
+    Reader that reassembles **global** per-vertex fields from goSPL's
+    *partitioned* HDF5 output.
+
+    goSPL writes one file per MPI partition per step
+    (``<base>.<step>.p<rank>.h5``) holding only that rank's local nodes, with the
+    partition meshes in ``topology.p<rank>.h5``. Provenance routing is global, so
+    this reader maps each partition's local nodes onto the **global input mesh**
+    ordering with a KDTree — the same local↔global map goSPL builds at load time
+    (``tree.query(lcoords)``) — and scatters each field into a global array.
+    Pass the global mesh coordinates (the ``npdata`` mesh ``v``) so the assembled
+    arrays line up with your per-vertex ``source_class`` / ``basin_id``.
+    """
+
+    def __init__(self, h5dir, global_coords, file_base="gospl"):
+        import glob
+        import os
+
+        import h5py
+        from scipy.spatial import cKDTree
+
+        self.h5dir = h5dir
+        self.file_base = file_base
+        self.npoints = len(global_coords)
+        tfiles = sorted(glob.glob(os.path.join(h5dir, "topology.p*.h5")))
+        if not tfiles:
+            raise FileNotFoundError("no topology.p*.h5 in %s" % h5dir)
+        tree = cKDTree(np.asarray(global_coords))
+        self.ranks, self.maps = [], []
+        for tf in tfiles:
+            rank = int(os.path.basename(tf).split(".p")[1].split(".h5")[0])
+            with h5py.File(tf, "r") as f:
+                lc = np.asarray(f["coords"])
+            _, gid = tree.query(lc)            # local node -> global vertex id
+            self.ranks.append(rank)
+            self.maps.append(gid.astype(np.int64))
+
+    def field(self, step, name):
+        """Assemble a global per-vertex array for ``name`` at output ``step``."""
+        import os
+
+        import h5py
+
+        out = np.zeros(self.npoints)
+        for rank, m in zip(self.ranks, self.maps):
+            df = os.path.join(
+                self.h5dir, "%s.%d.p%d.h5" % (self.file_base, step, rank)
+            )
+            with h5py.File(df, "r") as f:
+                v = np.asarray(f[name])
+            out[m] = v[:, 0] if v.ndim > 1 else v   # ghost overlaps agree
+        return out
+
+
+def _spec(s):
+    """Split a ``file.npz:key`` argument into (path, key)."""
+    path, _, key = s.rpartition(":")
+    if not path:
+        raise ValueError("expected file.npz:key, got %r" % s)
+    return path, key
+
+
+def main(argv=None):
+    """
+    CLI: attribute deposited sediment in sink basins to source rock types over a
+    goSPL run, and write a per-basin CSV + a per-pixel ``.npz``.
+
+    The global input mesh (``--mesh-npz``, the ``npdata`` file) defines the
+    vertex ordering; goSPL's *partitioned* output (``--h5dir`` with
+    ``<base>.<step>.p<rank>.h5`` + ``topology.p*.h5``) is reassembled onto it by
+    :class:`GosplOutput`. Source classes and basins are per-vertex ``.npz``
+    arrays in that same global ordering (rasterise your shapefiles with
+    :func:`classes_from_shapefile`). Routing defaults to MFD.
+    """
+    import argparse
+
+    p = argparse.ArgumentParser(description="goSPL sediment provenance attribution")
+    p.add_argument("--mesh-npz", required=True, type=_spec,
+                   help="global input mesh coords, as file.npz:key (e.g. mesh.npz:v)")
+    p.add_argument("--cells", type=_spec, default=None,
+                   help="global mesh cells, as file.npz:key (e.g. mesh.npz:c)")
+    p.add_argument("--h5dir", required=True,
+                   help="goSPL output h5/ directory (partitioned files)")
+    p.add_argument("--file-base", default="gospl", help="output file base name")
+    p.add_argument("--steps", required=True,
+                   help="output steps, inclusive range 'a:b' or comma list")
+    p.add_argument("--source", required=True, type=_spec,
+                   help="per-vertex source-class array, file.npz:key (int)")
+    p.add_argument("--n-classes", type=int, default=None)
+    p.add_argument("--basins", type=_spec, default=None,
+                   help="per-vertex sink-basin id array file.npz:key (-1 = none)")
+    p.add_argument("--cu-weights", default=None,
+                   help="comma-separated Cu fertility per class")
+    p.add_argument("--routing", choices=["mfd", "sfd"], default="mfd")
+    p.add_argument("--flow-exp", type=float, default=1.0)
+    p.add_argument("--elev-field", default="elev",
+                   help="HDF5 field used as the routing surface (e.g. waterFill)")
+    p.add_argument("--out-prefix", required=True)
+    args = p.parse_args(argv)
+
+    mp, mk = args.mesh_npz
+    coords = np.load(mp)[mk]
+    cells = None
+    if args.cells is not None:
+        cp, ck = args.cells
+        cells = np.load(cp)[ck]
+    if ":" in args.steps and args.steps.count(":") == 1 and "," not in args.steps:
+        a, b = (int(x) for x in args.steps.split(":"))
+        steps = range(a, b + 1)
+    else:
+        steps = [int(x) for x in args.steps.split(",")]
+
+    sp, sk = args.source
+    source_class = np.load(sp)[sk].astype(np.int64)
+    n_classes = args.n_classes or int(source_class.max() + 1)
+    basin_id = None
+    if args.basins is not None:
+        bp, bk = args.basins
+        basin_id = np.load(bp)[bk].astype(np.int64)
+    cu_weight = None
+    if args.cu_weights is not None:
+        cu_weight = np.array([float(x) for x in args.cu_weights.split(",")])
+
+    import h5py
+
+    reader = GosplOutput(args.h5dir, coords, file_base=args.file_base)
+    t = ProvenanceTracker(
+        coords, source_class, n_classes, cells=cells,
+        basin_id=basin_id, cu_weight=cu_weight,
+        routing=args.routing, flow_exp=args.flow_exp,
+    )
+
+    # Per-step output: one HDF5 holding the cumulative provenance state after
+    # each step (so the evolution is saved and can be viewed in ParaView), and a
+    # per-basin time series CSV.
+    steps = list(steps)
+    basin_rows = []
+    with h5py.File(args.out_prefix + ".h5", "w") as h:
+        g = h.create_group("mesh")
+        g["coords"] = coords
+        if cells is not None:
+            g["cells"] = cells
+        h["steps"] = np.asarray(steps)
+        for s in steps:
+            t.step(reader.field(s, args.elev_field), reader.field(s, "erodep"))
+            grp = h.create_group("step_%d" % s)
+            frac = t.pixel_fractions().astype("float32")
+            grp.create_dataset("fractions", data=frac, compression="gzip")
+            grp.create_dataset(
+                "dominant",
+                data=np.where(frac.sum(1) > 0, frac.argmax(1), -1).astype("int32"),
+                compression="gzip",
+            )
+            grp.create_dataset(
+                "distance", data=t.mean_distance().astype("float32"), compression="gzip"
+            )
+            if cu_weight is not None:
+                grp.create_dataset(
+                    "cu_fraction", data=t.cu_fraction().astype("float32"),
+                    compression="gzip",
+                )
+            if basin_id is not None:
+                for b, pct in t.basin_percentages().items():
+                    basin_rows.append((s, b, pct))
+    print("wrote %s.h5 (%d steps)" % (args.out_prefix, len(steps)))
+
+    if basin_id is not None:
+        with open(args.out_prefix + "_basins.csv", "w") as fh:
+            fh.write("step,basin," + ",".join("class%d" % c for c in range(n_classes)) + "\n")
+            for s, b, pct in basin_rows:
+                fh.write("%d,%d,%s\n" % (s, b, ",".join("%.3f" % v for v in pct)))
+        print("wrote %s_basins.csv (per-step basin %%)" % args.out_prefix)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,148 @@
+"""
+Tests for the sediment-provenance post-processor (gospl.analyse.provenance):
+source-to-sink attribution by fraction routing on synthetic meshes, plus the
+adjacency / receiver / downhill-edge helpers. Pure NumPy — no GIS/HDF5 needed.
+"""
+
+import numpy as np
+import pytest
+
+prov = pytest.importorskip("gospl.analyse.provenance")
+
+
+def _chain():
+    """A 5-node line 0->1->2->3->4 (node 4 the outlet), spacing 1, decreasing
+    elevation so each node drains to the next."""
+    coords = np.array([[float(i), 0.0] for i in range(5)])
+    elev = np.array([4.0, 3.0, 2.0, 1.0, 0.0])
+    indptr = np.array([0, 1, 3, 5, 7, 8])
+    indices = np.array([1, 0, 2, 1, 3, 2, 4, 3])
+    return coords, elev, (indptr, indices)
+
+
+def test_build_neighbours_and_receivers():
+    # Two triangles sharing an edge: vertices 0-1-2 and 1-2-3.
+    cells = np.array([[0, 1, 2], [1, 2, 3]])
+    indptr, indices = prov.build_neighbours(cells, 4)
+    nbr = {i: set(indices[indptr[i]:indptr[i + 1]].tolist()) for i in range(4)}
+    assert nbr[0] == {1, 2}
+    assert nbr[1] == {0, 2, 3}
+    assert nbr[2] == {0, 1, 3}
+    assert nbr[3] == {1, 2}
+
+    elev = np.array([3.0, 2.0, 2.5, 0.0])
+    rcv = prov.steepest_receivers(elev, indptr, indices)
+    assert rcv[0] == 1            # lowest lower neighbour of 0 is 1
+    assert rcv[1] == 3            # 1 -> 3 (0.0)
+    assert rcv[3] == 3            # outlet (no lower neighbour)
+
+
+def test_provenance_mixing_distance_conservation():
+    coords, elev, nbr = _chain()
+    source_class = np.array([0, 1, 0, 0, 0])      # node0 class 0, node1 class 1
+    t = prov.ProvenanceTracker(
+        coords, source_class, n_classes=2, neighbours=nbr,
+        basin_id=np.array([-1, -1, -1, 0, -1]),    # node 3 is the sink basin
+        cu_weight=np.array([1.0, 0.0]),            # class 0 is Cu-fertile
+    )
+    t.step(elev, np.zeros(5))                      # prime (erodep_prev = 0)
+    # Erode 2 m at node 0 and 1 m at node 1; deposit 3 m at node 3.
+    t.step(elev, np.array([-2.0, -1.0, 0.0, 3.0, 0.0]))
+
+    assert np.isclose(t.dep.sum(), 3.0)            # all eroded volume deposited
+    assert np.isclose(t.exported.sum(), 0.0)
+    frac = t.pixel_fractions()[3]                  # 2/3 class-0, 1/3 class-1
+    assert np.allclose(frac, [2.0 / 3.0, 1.0 / 3.0])
+    pct = t.basin_percentages()[0]
+    assert np.allclose(pct, [200.0 / 3.0, 100.0 / 3.0])
+    assert np.isclose(t.mean_distance()[3], 8.0 / 3.0)   # (2*3 + 1*2)/3
+    assert np.isclose(t.cu_fraction()[3], 2.0 / 3.0)
+
+
+def test_provenance_recycling():
+    """Sediment deposited then re-eroded carries its mixed provenance onward."""
+    coords, elev, nbr = _chain()
+    source_class = np.array([0, 1, 2, 2, 2])
+    t = prov.ProvenanceTracker(coords, source_class, n_classes=3, neighbours=nbr)
+    t.step(elev, np.zeros(5))
+    # Erode node0 (class0) + node1 (class1); deposit the mix at node 3.
+    t.step(elev, np.array([-2.0, -1.0, 0.0, 3.0, 0.0]))
+    assert np.allclose(t.pixel_fractions()[3], [2.0 / 3.0, 1.0 / 3.0, 0.0])
+
+    # Re-erode node 3's pile (Δerodep[3] = -3) and deposit at node 4.
+    t.step(elev, np.array([-2.0, -1.0, 0.0, 0.0, 3.0]))
+    assert t.pile[3].sum() < 1.0e-9, "pile not re-entrained"
+    # The recycled deposit at node 4 keeps the 2:1 class0:class1 ratio (no
+    # class-2 bedrock added, since only the pile eroded).
+    assert np.allclose(t.dep[4], [2.0, 1.0]) if t.dep.shape[1] == 2 else \
+        np.allclose(t.dep[4], [2.0, 1.0, 0.0])
+
+
+def _fan():
+    """node 0 (source) drains to two lower neighbours 1 and 2 at equal distance
+    but different slope; both are sinks (deposit everything)."""
+    coords = np.array([[0.0, 0.0], [1.0, 0.0], [-1.0, 0.0], [0.0, -1.0]])
+    elev = np.array([2.0, 1.0, 0.0, -1.0])         # slope 0->1 = 1, 0->2 = 2
+    indptr = np.array([0, 2, 4, 6, 8])
+    indices = np.array([1, 2, 0, 3, 0, 3, 1, 2])
+    return coords, elev, (indptr, indices)
+
+
+def test_mfd_splits_by_slope():
+    coords, elev, nbr = _fan()
+    src = np.array([0, 0, 0, 0])
+    # MFD: node 0's 3 m^3 splits by slope (1 vs 2) -> 1/3 to node1, 2/3 to node2.
+    t = prov.ProvenanceTracker(coords, src, n_classes=1, neighbours=nbr, routing="mfd")
+    t.step(elev, np.zeros(4))
+    t.step(elev, np.array([-3.0, 10.0, 10.0, 0.0]))   # erode 3 at 0; sinks at 1,2
+    assert np.isclose(t.dep.sum(), 3.0)               # conserved
+    assert np.isclose(t.dep[1, 0], 1.0)               # slope-1 branch
+    assert np.isclose(t.dep[2, 0], 2.0)               # slope-2 branch (steeper)
+
+    # SFD: everything goes to the single steepest neighbour (node 2).
+    t2 = prov.ProvenanceTracker(coords, src, n_classes=1, neighbours=nbr, routing="sfd")
+    t2.step(elev, np.zeros(4))
+    t2.step(elev, np.array([-3.0, 10.0, 10.0, 0.0]))
+    assert np.isclose(t2.dep[2, 0], 3.0)
+    assert np.isclose(t2.dep[1, 0], 0.0)
+
+
+def test_source_class_validation():
+    """source_class must be a full per-vertex array in [0, n_classes)."""
+    coords, _, nbr = _chain()
+    # -1 (unclassified) is rejected — assign a background class instead.
+    with pytest.raises(ValueError):
+        prov.ProvenanceTracker(coords, np.array([-1, 0, 0, 0, 0]), 2, neighbours=nbr)
+    # out-of-range class is rejected.
+    with pytest.raises(ValueError):
+        prov.ProvenanceTracker(coords, np.array([0, 0, 0, 0, 5]), 2, neighbours=nbr)
+    # wrong length is rejected.
+    with pytest.raises(ValueError):
+        prov.ProvenanceTracker(coords, np.array([0, 1]), 2, neighbours=nbr)
+    # neither cells nor neighbours -> error.
+    with pytest.raises(ValueError):
+        prov.ProvenanceTracker(coords, np.zeros(5, int), 1)
+
+
+def test_gospl_output_partition_reassembly(tmp_path):
+    """GosplOutput stitches goSPL's per-partition HDF5 onto the global mesh
+    ordering (shared ghost nodes agree)."""
+    h5py = pytest.importorskip("h5py")
+    pytest.importorskip("scipy")
+
+    # Global mesh: 4 vertices in a line.
+    gcoords = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+    d = tmp_path
+    # Partition 0 owns global {0,1,2}; partition 1 owns {2,3} (node 2 shared).
+    with h5py.File(d / "topology.p0.h5", "w") as f:
+        f["coords"] = gcoords[[0, 1, 2]]
+    with h5py.File(d / "topology.p1.h5", "w") as f:
+        f["coords"] = gcoords[[2, 3]]
+    with h5py.File(d / "gospl.0.p0.h5", "w") as f:
+        f["erodep"] = np.array([[10.0], [20.0], [30.0]])
+    with h5py.File(d / "gospl.0.p1.h5", "w") as f:
+        f["erodep"] = np.array([[30.0], [40.0]])   # node 2 agrees (30)
+
+    reader = prov.GosplOutput(str(d), gcoords)
+    ed = reader.field(0, "erodep")
+    assert np.allclose(ed, [10.0, 20.0, 30.0, 40.0])   # reassembled in global order


### PR DESCRIPTION
Standalone post-processor that attributes the sediment deposited in **sink basins** to user **source-rock polygons**, per basin and per pixel, with transport distance and an optional **copper-fertility** layer. Design + in-model scope: `docs/DESIGN_PROVENANCE.md`.

**Method** (Approach A — fraction/particle tracking on goSPL output): each output step, the net `erodep` change gives the eroded volume (recycled from the local deposited pile + fresh bedrock of the node's source class) and the deposited volume; the eroded material is routed downstream on the re-derived flow graph and laid down where the model deposits, carrying provenance + distance. Routing is **MFD** by default (flux splits across lower neighbours by slope, so a source can feed several basins) with SFD optional. Conservation holds per step.

**Partitioned I/O:** `GosplOutput` reassembles goSPL's per-rank-per-step HDF5 onto the global input-mesh ordering via a KDTree (the same local↔global map goSPL builds), so per-vertex `source_class`/`basin_id` line up. The CLI writes **per-step** provenance to one HDF5 (`/step_<s>/{fractions,dominant,distance,cu_fraction}`) + a per-basin time-series CSV. `classes_from_shapefile` (lazy geopandas) builds tracker-ready class arrays with a background class.

**Inputs documented** (required vs optional — `basin_id` is optional, only for the per-basin roll-up) and `source_class` is validated on construction.

**Performance:** vectorised flow-graph build; the topological sweep is O(N+E)/step (production path — numba JIT or the sparse transport-with-loss solve — noted in the design doc).

Caveats (design doc): sees net erodep per *output* step, re-derives routing, approximate volumes (exact ⇒ in-model tracer, Approach B); provenance ≠ prospectivity (Cu layer is a fertility-weighted detritus proxy).

Tests: adjacency/receivers, MFD-vs-SFD split, mixing/distance/conservation, recycling, input validation, partition reassembly. 49 passed, 1 skipped.