### PR TITLE
fix(ice): clamp sub-tolerance KSP noise in glacial-till routing weights

### DIFF
--- a/gospl/flow/iceplex.py
+++ b/gospl/flow/iceplex.py
@@ -594,7 +594,9 @@ class IceMesh(object):
         # the KSP solve is only accurate to its tolerance, so normalise by the
         # ACTUAL routed total (not Vtot) to make the weight sum to one exactly —
         # mass conservation then matches the melt-weighted path bit-for-bit.
-        dep_vol = f * L
+        # The analytical load is non-negative; clamp away sub-tolerance KSP
+        # residual noise so the deposition weight can never go slightly negative.
+        dep_vol = np.maximum(f * L, 0.0)
         total = MPI.COMM_WORLD.allreduce(
             float(np.sum(dep_vol[owned])), op=MPI.SUM
         )


### PR DESCRIPTION
## Summary

Fixes a flaky failure of `test_ice_till_routing` in the full slow suite.

`_routeTill` normalises the deposition weight by the KSP-solved till load `L`. The analytical load is non-negative, but the KSP solve is only accurate to its tolerance, so a cell can carry tiny negative residual noise (~1e-13). Run in isolation the solver converges just inside the test's `-1e-12` floor; inside the full suite, accumulated solver state pushes one cell just past it, failing the non-negativity assertion.

## Fix

Clamp `f*L` to `>= 0` before normalising. Negative till deposition is unphysical, the clamped mass is sub-tolerance, and conservation (`Σw = 1`) is preserved by the normalisation.

Full slow suite: **30 passed, 1 skipped**.