### PR TITLE
perf: wall-clock phase profiler + Gadi scaling harness + configurable output compression

### DIFF
--- a/gospl/model.py
+++ b/gospl/model.py
@@ -20,6 +20,7 @@ if "READTHEDOCS" not in os.environ:
     from .tools import GridProcess as _GridProcess
     from .mesher import Tectonics as _Tectonics
     from .tools import WriteMesh as _WriteMesh
+    from .tools import Profiler as _Profiler
 
 else:
 
@@ -87,7 +88,20 @@ else:
         def __init__(self):
             pass
 
+    class _Profiler(object):
+        def __init__(self, *args, **kwargs):
+            self.enabled = False
+
+        def phase(self, name):
+            from contextlib import nullcontext
+
+            return nullcontext()
+
+        def report(self, *args, **kwargs):
+            return None
+
 MPIrank = MPI.COMM_WORLD.Get_rank()
+MPIsize = MPI.COMM_WORLD.Get_size()
 
 
 class Model(
@@ -124,7 +138,7 @@ class Model(
     """
 
     def __init__(
-        self, filename, verbose=True, showlog=False, *args, **kwargs
+        self, filename, verbose=True, showlog=False, profile=False, *args, **kwargs
     ):
 
         self.showlog = showlog
@@ -134,6 +148,12 @@ class Model(
 
         # Read input dataset
         _ReadYaml.__init__(self, filename)
+
+        # Wall-clock phase profiler. Enabled by the `profile` kwarg OR the
+        # YAML `output: profile: true` flag (parsed in _readOut). When off it
+        # is a zero-overhead no-op. See gospl/tools/profiler.py.
+        prof_on = profile or bool(getattr(self, "profileFlag", False))
+        self.profiler = _Profiler(enabled=prof_on)
 
         # Stratigraphy initialisation
         _STRAMesh.__init__(self)
@@ -214,14 +234,18 @@ class Model(
 
         """
 
+        runStart = MPI.Wtime()
+
         while self.tNow <= self.tEnd:
             tstep = process_time()
 
             # Output time step
-            _Tectonics.updatePaleoZ(self)
-            _WriteMesh.visModel(self)
+            with self.profiler.phase("tectonics"):
+                _Tectonics.updatePaleoZ(self)
+            with self.profiler.phase("output"):
+                _WriteMesh.visModel(self)
             if self.tNow == self.tEnd:
-                return
+                break
 
             # Create new stratal layer
             newLayer = self.tNow >= self.saveStrat
@@ -230,55 +254,67 @@ class Model(
                 self.saveStrat += self.strat
 
             # Perform advection and tectonics
-            _Tectonics.getTectonics(self)
+            with self.profiler.phase("tectonics"):
+                _Tectonics.getTectonics(self)
 
             if not self.fast:
                 if self.iceOn:
                     # Compute ice accumulation
-                    _IceMesh.iceAccumulation(self)
+                    with self.profiler.phase("ice"):
+                        _IceMesh.iceAccumulation(self)
                 # Compute flow accumulation
-                _FAMesh.flowAccumulation(self)
+                with self.profiler.phase("flow"):
+                    _FAMesh.flowAccumulation(self)
 
                 # Perform River Incision/Deposition based on Stream Power Law (different flavors)
-                if self.cptSoil:
-                    # Non-linear coupled to soil production
-                    _soilSPL.erodepSPLsoil(self)
-                elif self.spl_n == 1.0:
-                    # Linear slope dependencies
-                    _SPL.erodepSPL(self)
-                else:
-                    # Non-linear slope dependencies
-                    _nlSPL.erodepSPLnl(self)
+                with self.profiler.phase("erosion"):
+                    if self.cptSoil:
+                        # Non-linear coupled to soil production
+                        _soilSPL.erodepSPLsoil(self)
+                    elif self.spl_n == 1.0:
+                        # Linear slope dependencies
+                        _SPL.erodepSPL(self)
+                    else:
+                        # Non-linear slope dependencies
+                        _nlSPL.erodepSPLnl(self)
 
                 # Glacial till: abrasion-produced till transported by ice and
                 # deposited (melt-out) as moraine in the ablation zone (SIA +
                 # till only; no-op otherwise). Done before fluvial deposition
                 # so the moraine is reworked by meltwater/rivers this step.
                 if self.iceOn:
-                    _IceMesh.glacialTill(self)
+                    with self.profiler.phase("till"):
+                        _IceMesh.glacialTill(self)
 
                 if not self.nodep:
                     # Downstream sediment deposition over the continents
-                    _FAMesh.flowAccumulation(self)
-                    _SEDMesh.sedChange(self)
+                    with self.profiler.phase("flow"):
+                        _FAMesh.flowAccumulation(self)
+                    with self.profiler.phase("sed"):
+                        _SEDMesh.sedChange(self)
                     if self.seaDepo:
                         # Downstream sediment deposition in marine environments
-                        _SEAMesh.seaChange(self)
+                        with self.profiler.phase("sea"):
+                            _SEAMesh.seaChange(self)
 
                 # Hillslope diffusion (linear and non-linear)
-                _hillSLP.getHillslope(self)
+                with self.profiler.phase("hillslope"):
+                    _hillSLP.getHillslope(self)
 
             if newLayer:
                 # Stratigraphic layer porosity and thicknesses under compaction
-                _STRAMesh.getCompaction(self)
+                with self.profiler.phase("strat"):
+                    _STRAMesh.getCompaction(self)
 
             # Apply flexural isostasy (local and global)
             if self.flexOn:
-                _GridProcess.applyFlexure(self)
+                with self.profiler.phase("flexure"):
+                    _GridProcess.applyFlexure(self)
 
             # Update tectonic, sea-level & climatic conditions
             if self.tNow < self.tEnd:
-                _UnstMesh.applyForces(self)
+                with self.profiler.phase("forcing"):
+                    _UnstMesh.applyForces(self)
 
             # Advance time
             self.tNow += self.dt
@@ -290,6 +326,10 @@ class Model(
                     flush=True,
                 )
 
+        # Cross-rank wall-clock profile + machine-readable profile.json
+        # (collective; a no-op when profiling is disabled).
+        self.profiler.report(self.outputDir, total_wall=MPI.Wtime() - runStart)
+
         return
 
     def destroy(self):
@@ -298,6 +338,23 @@ class Model(
 
         Safely quit model.
         """
+
+        # When `showlog` is set, dump the PETSc Log summary (KSP/SNES/TS solver
+        # timings, flop counts, MPI reductions) so solver-level performance is
+        # captured alongside the wall-clock phase profile. Best-effort: a
+        # missing viewer/log API must not break a clean shutdown.
+        if getattr(self, "showlog", False) and getattr(self, "log", None) is not None:
+            try:
+                import petsc4py
+
+                viewer = petsc4py.PETSc.Viewer().createASCII(
+                    os.path.join(self.outputDir, "petsc_log.txt"),
+                    comm=petsc4py.PETSc.COMM_WORLD,
+                )
+                petsc4py.PETSc.Log.view(viewer)
+                viewer.destroy()
+            except Exception:
+                pass
 
         _UnstMesh.destroy_DMPlex(self)
 

--- a/gospl/tools/__init__.py
+++ b/gospl/tools/__init__.py
@@ -4,3 +4,4 @@ Input/output methods declaration and additional processes related to flexure and
 from .inputparser import ReadYaml
 from .addprocess import GridProcess
 from .outmesh import WriteMesh
+from .profiler import Profiler

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -1948,9 +1948,17 @@ class ReadYaml(object):
             outDict = self.input["output"]
             self.outputDir = outDict.get("dir", "output")
             self.makedir = outDict.get("makedir", False)
+            # Opt-in wall-clock phase profiler (see gospl/tools/profiler.py).
+            self.profileFlag = outDict.get("profile", False)
+            # HDF5 output compression. `gzip` (default) keeps the historical
+            # behaviour; an int sets the gzip level (0-9); `none`/False writes
+            # uncompressed (faster I/O, larger files) — see outmesh._h5opts.
+            self.outCompress = outDict.get("compression", "gzip")
         except KeyError:
             self.outputDir = "output"
             self.makedir = False
+            self.profileFlag = False
+            self.outCompress = "gzip"
 
         if self.rStep > 0:
             self.makedir = False

--- a/gospl/tools/outmesh.py
+++ b/gospl/tools/outmesh.py
@@ -36,6 +36,25 @@ class WriteMesh(object):
         self.step = 0
         self.stratStep = 1
         self.file = "gospl"
+
+        # HDF5 dataset compression options, applied to every create_dataset via
+        # `**self._h5opts`. Driven by the YAML `output: compression:` setting
+        # (parsed in inputparser._readOut -> self.outCompress):
+        #   "gzip" (default)  -> {"compression": "gzip"}  (historical behaviour)
+        #   int 0..9          -> gzip at that level (trade CPU for file size)
+        #   "none"/False/None -> {}  (uncompressed: fastest I/O, largest files)
+        # gzip is CPU-serial per dataset and can dominate wall-clock at scale
+        # and high output cadence; disabling it trades disk for speed.
+        comp = getattr(self, "outCompress", "gzip")
+        if comp in (None, False, "none", "None", ""):
+            self._h5opts = {}
+        elif isinstance(comp, bool):  # True -> default gzip
+            self._h5opts = {"compression": "gzip"}
+        elif isinstance(comp, int):
+            self._h5opts = {"compression": "gzip", "compression_opts": comp}
+        else:
+            self._h5opts = {"compression": comp}
+
         if MPIrank == 0:
             self._createOutputDir()
 
@@ -151,7 +170,7 @@ class WriteMesh(object):
                 "stratZ",
                 shape=(self.lpoints, self.stratStep + 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             f["stratZ"][:, : self.stratStep + 1] = self.stratZ[:, : self.stratStep + 1]
 
@@ -160,7 +179,7 @@ class WriteMesh(object):
                 "stratH",
                 shape=(self.lpoints, self.stratStep + 1),
                 dtype="float64",
-                compression="gzip",
+                **self._h5opts,
             )
             f["stratH"][:, : self.stratStep + 1] = self.stratH[:, : self.stratStep + 1]
 
@@ -169,7 +188,7 @@ class WriteMesh(object):
                 "phiS",
                 shape=(self.lpoints, self.stratStep + 1),
                 dtype="float64",
-                compression="gzip",
+                **self._h5opts,
             )
             f["phiS"][:, : self.stratStep + 1] = self.phiS[:, : self.stratStep + 1]
 
@@ -182,7 +201,7 @@ class WriteMesh(object):
                     "stratK",
                     shape=(self.lpoints, self.stratStep + 1),
                     dtype="float64",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["stratK"][:, : self.stratStep + 1] = self.stratK[
                     :, : self.stratStep + 1
@@ -196,7 +215,7 @@ class WriteMesh(object):
                     "stratHf",
                     shape=(self.lpoints, self.stratStep + 1),
                     dtype="float64",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["stratHf"][:, : self.stratStep + 1] = self.stratHf[
                     :, : self.stratStep + 1
@@ -205,7 +224,7 @@ class WriteMesh(object):
                     "phiF",
                     shape=(self.lpoints, self.stratStep + 1),
                     dtype="float64",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["phiF"][:, : self.stratStep + 1] = self.phiF[:, : self.stratStep + 1]
 
@@ -216,7 +235,7 @@ class WriteMesh(object):
                     "stratP",
                     shape=(self.lpoints, self.stratStep + 1, self.provNb),
                     dtype="float64",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["stratP"][:, : self.stratStep + 1, :] = self.stratP[
                     :, : self.stratStep + 1, :
@@ -259,14 +278,14 @@ class WriteMesh(object):
                     "coords",
                     shape=(self.lpoints, 3),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["coords"][:, :] = self.lcoords
                 f.create_dataset(
                     "cells",
                     shape=(len(self.lcells[:, 0]), 3),
                     dtype="int32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["cells"][:, :] = self.lcells + 1
             self.elems = MPIcomm.gather(len(self.lcells[:, 0]), root=0)
@@ -287,21 +306,21 @@ class WriteMesh(object):
                 "elev",
                 shape=(self.lpoints, 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             f["elev"][:, 0] = self.hLocal.getArray()
             f.create_dataset(
                 "erodep",
                 shape=(self.lpoints, 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             f["erodep"][:, 0] = self.cumEDLocal.getArray()
             f.create_dataset(
                 "EDrate",
                 shape=(self.lpoints, 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             data = self.EbLocal.getArray().copy()
             f["EDrate"][:, 0] = data
@@ -310,14 +329,14 @@ class WriteMesh(object):
                     "waterFill",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["waterFill"][:, 0] = self.waterFilled
             f.create_dataset(
                 "fillFA",
                 shape=(self.lpoints, 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             data = self.fillFAL.getArray().copy()
             data[data <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
@@ -328,7 +347,7 @@ class WriteMesh(object):
                 "FA",
                 shape=(self.lpoints, 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             data = self.FAL.getArray().copy()
             data[data <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
@@ -341,7 +360,7 @@ class WriteMesh(object):
                     "iceH",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 data = self.iceHL.getArray().copy()
                 data[data <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
@@ -355,7 +374,7 @@ class WriteMesh(object):
                     "iceUb",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["iceUb"][:, 0] = self.iceUbL.getArray().copy()
 
@@ -365,7 +384,7 @@ class WriteMesh(object):
                     "iceMelt",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["iceMelt"][:, 0] = self.iceMeltL.getArray().copy()
 
@@ -375,7 +394,7 @@ class WriteMesh(object):
                     "iceAbr",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["iceAbr"][:, 0] = self.iceAbrL.getArray().copy()
 
@@ -384,7 +403,7 @@ class WriteMesh(object):
                     "flexIso",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["flexIso"][:, 0] = self.localFlex
             if self.cptSoil:
@@ -392,7 +411,7 @@ class WriteMesh(object):
                     "soilH",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["soilH"][:, 0] = self.Lsoil.getArray().copy()
 
@@ -400,7 +419,7 @@ class WriteMesh(object):
                 "sedLoad",
                 shape=(self.lpoints, 1),
                 dtype="float32",
-                compression="gzip",
+                **self._h5opts,
             )
             data = self.vSedLocal.getArray().copy()
             data[data <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
@@ -413,7 +432,7 @@ class WriteMesh(object):
                     "sedLoadF",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 dataF = self.vSedFLocal.getArray().copy()
                 dataF[dataF <= DISCHARGE_FLOOR] = DISCHARGE_FLOOR
@@ -423,7 +442,7 @@ class WriteMesh(object):
                     "uplift",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["uplift"][:, 0] = self.upsub
             if self.rainVal is not None:
@@ -431,7 +450,7 @@ class WriteMesh(object):
                     "rain",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["rain"][:, 0] = self.rainVal
             if self.evapdata is not None and self.evapVal is not None:
@@ -439,7 +458,7 @@ class WriteMesh(object):
                     "evap",
                     shape=(self.lpoints, 1),
                     dtype="float32",
-                    compression="gzip",
+                    **self._h5opts,
                 )
                 f["evap"][:, 0] = self.evapVal
             if self.memclear:

--- a/gospl/tools/profiler.py
+++ b/gospl/tools/profiler.py
@@ -1,0 +1,230 @@
+"""
+Lightweight wall-clock phase profiler for goSPL.
+
+Motivation
+----------
+The pre-existing per-phase ``process_time()`` prints in goSPL measure
+per-process *CPU* time, gated behind ``verbose``. CPU time is the wrong clock
+for a parallel run: under MPI it either hides time a rank spends blocked in a
+collective (sleep-wait) or counts busy-wait spinning as if it were useful
+compute. Either way it makes load imbalance invisible, which is exactly the
+thing you need to see when scaling across CPUs.
+
+This module provides :class:`Profiler`, a small wall-clock timer that:
+
+* uses ``MPI.Wtime()`` (the MPI standard wall clock),
+* accumulates elapsed seconds and call counts per named phase,
+* does **no** collective communication inside the time loop — the only
+  reduction happens once, in :meth:`report` — so per-step overhead is two
+  ``Wtime`` calls per phase,
+* is a true no-op when disabled (``phase`` returns a shared ``nullcontext``),
+* at the end reduces min/mean/max across ranks and prints a load-imbalance
+  table on rank 0, also writing a machine-readable ``profile.json`` consumed by
+  the scaling harness (``scripts/scaling/``).
+
+Usage
+-----
+::
+
+    self.profiler = Profiler(enabled=True)
+    with self.profiler.phase("flow"):
+        self.flowAccumulation()
+    ...
+    self.profiler.report(outputDir, total_wall=elapsed)
+
+When disabled the ``with`` block costs nothing measurable.
+"""
+
+import os
+import json
+from contextlib import nullcontext
+
+import numpy as np
+from mpi4py import MPI
+
+
+class Profiler(object):
+    """Accumulate per-phase wall-clock time and report cross-rank statistics.
+
+    :arg enabled: when ``False`` every method is a no-op (zero overhead).
+    :arg comm: MPI communicator (defaults to ``MPI.COMM_WORLD``).
+    """
+
+    class _Timer(object):
+        """Context manager that charges its elapsed wall time to one phase."""
+
+        __slots__ = ("_prof", "_name", "_t0")
+
+        def __init__(self, prof, name):
+            self._prof = prof
+            self._name = name
+
+        def __enter__(self):
+            self._t0 = MPI.Wtime()
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            dt = MPI.Wtime() - self._t0
+            self._prof._accumulate(self._name, dt)
+            return False
+
+    def __init__(self, enabled=False, comm=None):
+        self.enabled = bool(enabled)
+        self.comm = comm if comm is not None else MPI.COMM_WORLD
+        self.times = {}
+        self.counts = {}
+        self._order = []
+        # Shared zero-cost context returned when profiling is off.
+        self._null = nullcontext()
+
+    def _accumulate(self, name, dt):
+        if name not in self.times:
+            self.times[name] = 0.0
+            self.counts[name] = 0
+            self._order.append(name)
+        self.times[name] += dt
+        self.counts[name] += 1
+
+    def phase(self, name):
+        """Return a context manager timing ``name`` (no-op when disabled)."""
+        if not self.enabled:
+            return self._null
+        return self._Timer(self, name)
+
+    def start(self, name):
+        """Imperative timer start; pair with :meth:`stop`."""
+        if not self.enabled:
+            return
+        self._starts = getattr(self, "_starts", {})
+        self._starts[name] = MPI.Wtime()
+
+    def stop(self, name):
+        """Imperative timer stop; pair with :meth:`start`."""
+        if not self.enabled:
+            return
+        t0 = getattr(self, "_starts", {}).get(name)
+        if t0 is not None:
+            self._accumulate(name, MPI.Wtime() - t0)
+
+    def reduce(self, total_wall=None):
+        """Reduce the per-phase timings across all ranks.
+
+        Collective: every rank MUST call this. Returns a dict (identical on
+        every rank) keyed by phase name with min/mean/max/imbalance/calls, plus
+        a ``__meta__`` entry. Returns ``None`` when disabled.
+        """
+        if not self.enabled:
+            return None
+
+        comm = self.comm
+        size = comm.Get_size()
+
+        # Union of phase names across ranks (a rank may skip a conditional
+        # phase, e.g. flexure-off), preserving first-seen order on rank 0.
+        gathered = comm.allgather(self._order)
+        names = []
+        seen = set()
+        for lst in gathered:
+            for n in lst:
+                if n not in seen:
+                    seen.add(n)
+                    names.append(n)
+
+        local = np.array([self.times.get(n, 0.0) for n in names], dtype=np.float64)
+        tmin = local.copy()
+        tmax = local.copy()
+        tsum = local.copy()
+        comm.Allreduce(MPI.IN_PLACE, tmin, op=MPI.MIN)
+        comm.Allreduce(MPI.IN_PLACE, tmax, op=MPI.MAX)
+        comm.Allreduce(MPI.IN_PLACE, tsum, op=MPI.SUM)
+        tmean = tsum / size
+
+        lcnt = np.array([self.counts.get(n, 0) for n in names], dtype=np.int64)
+        cmax = lcnt.copy()
+        comm.Allreduce(MPI.IN_PLACE, cmax, op=MPI.MAX)
+
+        if total_wall is not None:
+            twall = np.array([total_wall], dtype=np.float64)
+            comm.Allreduce(MPI.IN_PLACE, twall, op=MPI.MAX)
+            total_wall = float(twall[0])
+
+        out = {"__meta__": {"nranks": size, "total_wall": total_wall}}
+        for i, n in enumerate(names):
+            mean = float(tmean[i])
+            mx = float(tmax[i])
+            out[n] = {
+                "min": float(tmin[i]),
+                "mean": mean,
+                "max": mx,
+                "sum": float(tsum[i]),
+                # max/mean: 1.0 = perfectly balanced, >1 = imbalance.
+                "imbalance": (mx / mean) if mean > 0.0 else 0.0,
+                "calls": int(cmax[i]),
+            }
+        return out
+
+    def report(self, outputDir=None, filename="profile.json",
+               total_wall=None, to_stdout=True):
+        """Reduce, print a table (rank 0), and write ``profile.json``.
+
+        Collective: every rank MUST call this (it calls :meth:`reduce`).
+        """
+        stats = self.reduce(total_wall=total_wall)
+        if stats is None:
+            return None
+
+        if self.comm.Get_rank() != 0:
+            return stats
+
+        meta = stats["__meta__"]
+        phases = [(k, v) for k, v in stats.items() if k != "__meta__"]
+        # Sort by mean wall time, descending — biggest cost first.
+        phases.sort(key=lambda kv: kv[1]["mean"], reverse=True)
+
+        sum_mean = sum(v["mean"] for _, v in phases)
+        denom = meta["total_wall"] if meta["total_wall"] else sum_mean
+
+        if to_stdout:
+            nproc = meta["nranks"]
+            print("", flush=True)
+            print(
+                "================ goSPL wall-clock profile (P=%d ranks) ================"
+                % nproc,
+                flush=True,
+            )
+            print(
+                "%-14s %10s %7s %10s %10s %8s"
+                % ("phase", "mean(s)", "%", "max(s)", "imbal", "calls"),
+                flush=True,
+            )
+            print("-" * 64, flush=True)
+            for name, v in phases:
+                pct = (100.0 * v["mean"] / denom) if denom > 0 else 0.0
+                print(
+                    "%-14s %10.3f %6.1f%% %10.3f %10.2f %8d"
+                    % (name, v["mean"], pct, v["max"], v["imbalance"], v["calls"]),
+                    flush=True,
+                )
+            print("-" * 64, flush=True)
+            if meta["total_wall"]:
+                unacc = meta["total_wall"] - sum_mean
+                print("%-14s %10.3f" % ("TOTAL(wall)", meta["total_wall"]), flush=True)
+                print(
+                    "%-14s %10.3f %6.1f%%"
+                    % ("unaccounted", unacc, 100.0 * unacc / meta["total_wall"]),
+                    flush=True,
+                )
+            print("=" * 64, flush=True)
+
+        if outputDir is not None:
+            try:
+                path = os.path.join(outputDir, filename)
+                with open(path, "w") as fh:
+                    json.dump(stats, fh, indent=2)
+                if to_stdout:
+                    print("Wrote profile to %s" % path, flush=True)
+            except (IOError, OSError) as err:
+                if to_stdout:
+                    print("Could not write %s: %s" % (filename, err), flush=True)
+
+        return stats

--- a/scripts/scaling/README.md
+++ b/scripts/scaling/README.md
@@ -1,0 +1,88 @@
+# goSPL parallel-scaling harness
+
+Tools to measure how goSPL scales across CPU counts and where the wall-clock
+time goes. Built around the wall-clock phase profiler (`gospl/tools/profiler.py`,
+enabled with `Model(..., profile=True)` or YAML `output: profile: true`).
+
+| File | Role |
+|---|---|
+| `run_scaling.py` | mpirun/srun entry point: runs a capped number of steps with profiling, writes `scaling_p<N>.json` (timings + speedup inputs + peak RSS). |
+| `gadi_scaling.pbs` | PBS job for **one** rank count on NCI Gadi (native module build *or* Singularity container). |
+| `submit_sweep.sh` | qsub's `gadi_scaling.pbs` once per rank count (1,2,4,…,48). |
+| `analyze_scaling.py` | Reads all `scaling_p*.json`, computes speedup/efficiency, writes CSV + Markdown + plots to `results/scaling/`. |
+
+## What it measures
+
+- **Strong scaling**: same problem, more ranks → speedup `S(p)=T(base)/T(p)` and
+  efficiency `E(p)=S·base/p`.
+- **Per-phase wall time** (`flow`, `erosion`, `sed`, `sea`, `hillslope`,
+  `flexure`, `ice`, `till`, `strat`, `forcing`, `tectonics`, `output`) with a
+  cross-rank **load-imbalance** ratio (`max/mean`; 1.0 = balanced).
+- **Peak RSS per rank** — surfaces the global-array (`mpoints`) memory patterns
+  that don't shrink as you add ranks.
+
+`--io off` (the default) pushes the output cadence past the shortened end time
+so the numbers reflect compute + communication, not HDF5 bandwidth. Do one
+sweep with `--io on` to quantify the I/O share.
+
+## Quick local check (workstation)
+
+```bash
+cd tests/fixtures           # any dir whose YAML's relative paths resolve
+mpirun -n 2 python ../../scripts/scaling/run_scaling.py \
+    -i minimal.yml --steps 10 --io off --outdir /tmp/sc
+mpirun -n 1 python ../../scripts/scaling/run_scaling.py \
+    -i minimal.yml --steps 10 --io off --outdir /tmp/sc
+python ../../scripts/scaling/analyze_scaling.py /tmp/sc -o /tmp/sc/out
+```
+
+> The bundled fixtures (~3.8k nodes) are **far too small** to scale past a few
+> ranks — partitions become dominated by halo/communication. Use them only to
+> check the harness runs. For real numbers, point `-i` at a
+> production-resolution global-sphere input.
+
+## On NCI Gadi
+
+1. Edit `gadi_scaling.pbs`: set `#PBS -P <project>`, `-l storage`, and (native
+   mode) the `GOSPL_VENV` path or (container mode) `CONTAINER` `.sif` path.
+2. Submit a sweep (absolute input path; pick a representative production input):
+
+   ```bash
+   # native build (mirrors hpc_setup/nciRun.pbs modules)
+   PROJECT=q97 GOSPL_VENV=$HOME/envi_gospl/bin/activate \
+     ./submit_sweep.sh /scratch/q97/$USER/run/input.yml 1 2 4 8 16 24 48
+
+   # or the Singularity container
+   PROJECT=q97 MODE=container CONTAINER=/scratch/q97/$USER/gospl-hpc-v2026.6.13.sif \
+     ./submit_sweep.sh /scratch/q97/$USER/run/input.yml 1 2 4 8 16 24 48
+   ```
+
+   Each rank count is a separate job sized `mem = ranks × MEM_PER_CPU_GB`
+   (default 4 GB/rank). Counts >48 span multiple nodes — Gadi's `normal` queue
+   allocates in whole 48-core nodes, so use 48, 96, 192, … there.
+
+   Add `DEPEND=1` to chain the jobs (one at a time) for the cleanest timing on a
+   shared system.
+
+3. After they finish:
+
+   ```bash
+   python analyze_scaling.py /scratch/q97/$USER/run/scaling_results -o results/scaling
+   ```
+
+   → console table, `results/scaling/scaling_summary.{csv,md}`, and
+   `scaling_speedup.png` / `scaling_phases.png`.
+
+## Reading the results
+
+- **Efficiency falling off a cliff at some p** → that's where communication /
+  serial sections dominate. Cross-reference the per-phase plot: a phase whose
+  *mean* time stops dropping (or grows) with more ranks is the culprit.
+- **High imbalance (`max/mean` ≫ 1)** on a phase → load imbalance (uneven
+  partition work, e.g. all the ocean/ice on a few ranks).
+- **`rss_max_mb_per_rank` flat or rising with p** → a global-sized
+  (`mpoints`) allocation that doesn't decompose (the known flexure / advection /
+  marine `_matOcean` patterns — see the parallel-performance plan).
+
+Use `--steps` large enough that per-step cost dwarfs init, but small enough to
+keep the sweep cheap; 20–50 steps is usually plenty.

--- a/scripts/scaling/analyze_scaling.py
+++ b/scripts/scaling/analyze_scaling.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Analyse a goSPL scaling sweep.
+
+Reads the ``scaling_p<N>.json`` records produced by ``run_scaling.py`` (one per
+MPI rank count), computes strong-scaling speedup S(p)=T(p0)/T(p) and parallel
+efficiency E(p)=S(p)·p0/p relative to the smallest rank count in the sweep, and
+emits:
+
+  * a console table,
+  * ``results/scaling/scaling_summary.csv``  (raw numbers),
+  * ``results/scaling/scaling_summary.md``   (Markdown table for reports),
+  * ``results/scaling/scaling_speedup.png``  (speedup + efficiency vs p),
+  * ``results/scaling/scaling_phases.png``   (per-phase mean wall vs p, stacked),
+
+The plots are skipped (with a notice) if matplotlib is unavailable, so the CSV
+and Markdown always get written. This script is serial — run it on a login node
+after the sweep finishes.
+
+Usage::
+
+    python analyze_scaling.py scaling_results/ -o results/scaling
+"""
+
+import os
+import csv
+import glob
+import json
+import argparse
+
+
+def _load(indir):
+    records = []
+    for path in sorted(glob.glob(os.path.join(indir, "scaling_p*.json"))):
+        with open(path) as fh:
+            records.append(json.load(fh))
+    records.sort(key=lambda r: r["nranks"])
+    return records
+
+
+def _phase_union(records):
+    names, seen = [], set()
+    for r in records:
+        for n in r["phases"]:
+            if n not in seen:
+                seen.add(n)
+                names.append(n)
+    # Stable, biggest-first by total mean time across the sweep.
+    weight = {
+        n: sum(r["phases"].get(n, {}).get("mean", 0.0) for r in records) for n in names
+    }
+    names.sort(key=lambda n: weight[n], reverse=True)
+    return names
+
+
+def analyse(records):
+    base = records[0]
+    p0, t0 = base["nranks"], base["run_wall_s"]
+    rows = []
+    for r in records:
+        p, t = r["nranks"], r["run_wall_s"]
+        speedup = t0 / t if t > 0 else 0.0
+        eff = speedup * p0 / p if p > 0 else 0.0
+        rows.append(
+            {
+                "nranks": p,
+                "run_wall_s": t,
+                "speedup": speedup,
+                "efficiency": eff,
+                "rss_max_mb_per_rank": r.get("rss_max_mb_per_rank", float("nan")),
+                "rss_sum_mb": r.get("rss_sum_mb", float("nan")),
+            }
+        )
+    return rows, p0
+
+
+def write_csv(rows, names, records, path):
+    with open(path, "w", newline="") as fh:
+        w = csv.writer(fh)
+        header = [
+            "nranks",
+            "run_wall_s",
+            "speedup",
+            "efficiency",
+            "rss_max_mb_per_rank",
+            "rss_sum_mb",
+        ] + ["phase_%s_mean_s" % n for n in names] + [
+            "phase_%s_imbal" % n for n in names
+        ]
+        w.writerow(header)
+        for row, r in zip(rows, records):
+            line = [
+                row["nranks"],
+                "%.4f" % row["run_wall_s"],
+                "%.4f" % row["speedup"],
+                "%.4f" % row["efficiency"],
+                "%.1f" % row["rss_max_mb_per_rank"],
+                "%.1f" % row["rss_sum_mb"],
+            ]
+            line += ["%.4f" % r["phases"].get(n, {}).get("mean", 0.0) for n in names]
+            line += ["%.2f" % r["phases"].get(n, {}).get("imbalance", 0.0) for n in names]
+            w.writerow(line)
+
+
+def write_md(rows, p0, path):
+    lines = [
+        "# goSPL strong-scaling summary",
+        "",
+        "Baseline = %d rank(s). Speedup S(p)=T(base)/T(p); efficiency "
+        "E(p)=S·base/p (1.00 = perfect)." % p0,
+        "",
+        "| ranks | wall (s) | speedup | efficiency | RSS/rank (MB) |",
+        "|------:|---------:|--------:|-----------:|--------------:|",
+    ]
+    for row in rows:
+        lines.append(
+            "| %d | %.2f | %.2f | %.0f%% | %.0f |"
+            % (
+                row["nranks"],
+                row["run_wall_s"],
+                row["speedup"],
+                100.0 * row["efficiency"],
+                row["rss_max_mb_per_rank"],
+            )
+        )
+    with open(path, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def plot(rows, names, records, outdir):
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        print("[analyze] matplotlib/numpy not available — skipping plots")
+        return
+
+    ps = [r["nranks"] for r in rows]
+
+    # --- speedup + efficiency -------------------------------------------------
+    fig, ax1 = plt.subplots(figsize=(7, 5))
+    sp = [r["speedup"] for r in rows]
+    ax1.plot(ps, sp, "o-", color="tab:blue", label="measured speedup")
+    ax1.plot(
+        ps,
+        [p / ps[0] for p in ps],
+        "k--",
+        alpha=0.6,
+        label="ideal (linear)",
+    )
+    ax1.set_xlabel("MPI ranks")
+    ax1.set_ylabel("speedup", color="tab:blue")
+    ax1.set_xscale("log", base=2)
+    ax1.set_yscale("log", base=2)
+    ax1.set_xticks(ps)
+    ax1.get_xaxis().set_major_formatter(plt.ScalarFormatter())
+    ax1.grid(True, which="both", alpha=0.3)
+
+    ax2 = ax1.twinx()
+    ax2.plot(ps, [100 * r["efficiency"] for r in rows], "s-", color="tab:red",
+             label="efficiency")
+    ax2.set_ylabel("parallel efficiency (%)", color="tab:red")
+    ax2.set_ylim(0, 110)
+    ax1.legend(loc="upper left")
+    fig.suptitle("goSPL strong scaling")
+    fig.tight_layout()
+    p1 = os.path.join(outdir, "scaling_speedup.png")
+    fig.savefig(p1, dpi=130)
+    plt.close(fig)
+
+    # --- per-phase mean wall, stacked ----------------------------------------
+    fig, ax = plt.subplots(figsize=(8, 5))
+    bottom = np.zeros(len(ps))
+    x = np.arange(len(ps))
+    for n in names:
+        vals = np.array([r["phases"].get(n, {}).get("mean", 0.0) for r in records])
+        ax.bar(x, vals, bottom=bottom, label=n)
+        bottom += vals
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(p) for p in ps])
+    ax.set_xlabel("MPI ranks")
+    ax.set_ylabel("mean wall time per phase (s)")
+    ax.set_title("goSPL per-phase wall time vs ranks")
+    ax.legend(fontsize=8, ncol=2)
+    fig.tight_layout()
+    p2 = os.path.join(outdir, "scaling_phases.png")
+    fig.savefig(p2, dpi=130)
+    plt.close(fig)
+
+    print("[analyze] wrote %s and %s" % (p1, p2))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Analyse a goSPL scaling sweep")
+    parser.add_argument("indir", help="dir with scaling_p*.json records")
+    parser.add_argument("-o", "--outdir", default="results/scaling")
+    args = parser.parse_args(argv)
+
+    records = _load(args.indir)
+    if not records:
+        raise SystemExit("No scaling_p*.json found in %s" % args.indir)
+
+    names = _phase_union(records)
+    rows, p0 = analyse(records)
+    os.makedirs(args.outdir, exist_ok=True)
+
+    # Console table.
+    print("\ngoSPL strong scaling (baseline = %d rank(s))" % p0)
+    print("%6s %10s %9s %12s %14s" % ("ranks", "wall(s)", "speedup", "efficiency",
+                                      "RSS/rank(MB)"))
+    for row in rows:
+        print(
+            "%6d %10.2f %9.2f %11.0f%% %14.0f"
+            % (
+                row["nranks"],
+                row["run_wall_s"],
+                row["speedup"],
+                100.0 * row["efficiency"],
+                row["rss_max_mb_per_rank"],
+            )
+        )
+
+    write_csv(rows, names, records, os.path.join(args.outdir, "scaling_summary.csv"))
+    write_md(rows, p0, os.path.join(args.outdir, "scaling_summary.md"))
+    plot(rows, names, records, args.outdir)
+    print("\n[analyze] wrote CSV + Markdown to %s" % args.outdir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scaling/gadi_scaling.pbs
+++ b/scripts/scaling/gadi_scaling.pbs
@@ -1,0 +1,74 @@
+#!/bin/bash
+###############################################################################
+# NCI Gadi (PBS) job for ONE point of a goSPL strong-scaling sweep.
+#
+# Submitted (with per-job overrides) by submit_sweep.sh, but also runnable on
+# its own:
+#
+#   qsub -l ncpus=8 -l mem=32GB \
+#        -v NCPUS=8,INPUT=/path/to/input.yml,STEPS=20,IO=off,MODE=native,OUTDIR=$PWD/scaling_results \
+#        scripts/scaling/gadi_scaling.pbs
+#
+# Variables (all overridable via `qsub -v`):
+#   NCPUS   MPI ranks to launch (default: $PBS_NCPUS)
+#   INPUT   goSPL input YAML (absolute path recommended)
+#   STEPS   timesteps to run (default 20)
+#   IO      on|off  — 'off' isolates compute from HDF5 output (default off)
+#   MODE    native|container (default native)
+#   OUTDIR  where scaling_p<N>.json is written (default $PWD/scaling_results)
+#   CONTAINER  .sif path when MODE=container
+#   DRIVER  path to run_scaling.py (default: alongside this script)
+#
+# Edit the #PBS -P project code and -l storage before submitting.
+###############################################################################
+#PBS -P <project>
+#PBS -q normal
+#PBS -l ncpus=48
+#PBS -l mem=190GB
+#PBS -l walltime=00:30:00
+#PBS -l wd
+#PBS -l storage=scratch/<project>+gdata/<project>
+#PBS -N gospl_scaling
+
+set -euo pipefail
+
+NCPUS="${NCPUS:-${PBS_NCPUS:-1}}"
+INPUT="${INPUT:?set INPUT to the goSPL input YAML}"
+STEPS="${STEPS:-20}"
+IO="${IO:-off}"
+MODE="${MODE:-native}"
+OUTDIR="${OUTDIR:-$PWD/scaling_results}"
+DRIVER="${DRIVER:-$(dirname "$0")/run_scaling.py}"
+
+# One thread per MPI rank (AGENTS.md container invariant 2; also correct native).
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+
+# Run goSPL from the input's directory so the YAML's relative mesh/output paths
+# resolve (matches hpc_setup/nciRun.pbs convention).
+cd "$(dirname "$INPUT")"
+INPUT_BASE="$(basename "$INPUT")"
+
+echo "[gadi_scaling] MODE=$MODE NCPUS=$NCPUS STEPS=$STEPS IO=$IO INPUT=$INPUT"
+
+if [ "$MODE" = "container" ]; then
+    module load singularity
+    CONTAINER="${CONTAINER:?set CONTAINER to the .sif path for MODE=container}"
+    mpirun -np "$NCPUS" \
+        singularity exec "$CONTAINER" \
+            python "$DRIVER" -i "$INPUT_BASE" --steps "$STEPS" --io "$IO" \
+                --outdir "$OUTDIR" --tag container
+else
+    # Native build — mirror hpc_setup/nciRun.pbs module + venv setup.
+    module load intel-mpi/2021.13.0 hdf5/1.12.1p petsc/3.21.3 \
+        netcdf/4.9.2p intel-mkl/2023.2.0 python3/3.11.7
+    export PYTHONPATH="$PETSC_BASE/lib/mpich/Intel:$PYTHONPATH"
+    # Activate your goSPL venv (edit the path):
+    source "${GOSPL_VENV:-$HOME/envi_gospl/bin/activate}"
+    mpirun -np "$NCPUS" \
+        python3 "$DRIVER" -i "$INPUT_BASE" --steps "$STEPS" --io "$IO" \
+            --outdir "$OUTDIR" --tag native
+fi
+
+echo "[gadi_scaling] done -> $OUTDIR/scaling_p$(printf '%04d' "$NCPUS").json"

--- a/scripts/scaling/local_sweep.sh
+++ b/scripts/scaling/local_sweep.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+###############################################################################
+# Run a goSPL strong-scaling sweep on a local workstation (no PBS/Slurm).
+#
+# Runs run_scaling.py once per MPI rank count, *sequentially* (each run gets the
+# whole machine — concurrent runs would compete for cores and pollute timings),
+# writing scaling_p<N>.json into OUTDIR. Once every rank count is done it runs
+# analyze_scaling.py on OUTDIR.
+#
+# This is the workstation counterpart of submit_sweep.sh (which qsubs one PBS
+# job per rank count on NCI Gadi).
+#
+# Usage:
+#   ./local_sweep.sh /path/to/input.yml [ranks...]
+#
+# Examples:
+#   ./local_sweep.sh /path/to/input.yml              # 1 2 3 4 5 6 (default)
+#   ./local_sweep.sh /path/to/input.yml 1 2 4 6      # custom set
+#
+# Environment overrides:
+#   STEPS         timesteps per run (default 20)
+#   IO            on|off (default off — compute-only)
+#   OUTDIR        results dir (default $PWD/scaling_results)
+#   ANALYZE       1|0 run analyze_scaling.py at the end (default 1)
+#   ANALYZE_OUT   analyze output dir (default $OUTDIR/summary)
+#   MPIRUN        launcher (default mpirun)
+#   PYTHON        python interpreter (default python)
+#   OVERSUBSCRIBE 1|0 pass --oversubscribe to Open MPI when ranks > cores
+#                 (auto-enabled if a rank count exceeds the detected core count)
+#   MPIRUN_ARGS   extra args appended verbatim to every mpirun invocation
+###############################################################################
+set -euo pipefail
+
+INPUT="${1:?usage: local_sweep.sh <input.yml> [ranks...]}"
+shift || true
+RANKS=("$@")
+if [ "${#RANKS[@]}" -eq 0 ]; then
+    RANKS=(1 2 3 4 5 6)
+fi
+
+STEPS="${STEPS:-20}"
+IO="${IO:-off}"
+OUTDIR="${OUTDIR:-$PWD/scaling_results}"
+ANALYZE="${ANALYZE:-1}"
+ANALYZE_OUT="${ANALYZE_OUT:-$OUTDIR/summary}"
+MPIRUN="${MPIRUN:-mpirun}"
+PYTHON="${PYTHON:-python}"
+MPIRUN_ARGS="${MPIRUN_ARGS:-}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DRIVER="$HERE/run_scaling.py"
+ANALYZER="$HERE/analyze_scaling.py"
+
+# Resolve the input to an absolute path: goSPL resolves the YAML's relative
+# paths against the cwd, so we cd into the input's directory before each run.
+INPUT_DIR="$(cd "$(dirname "$INPUT")" && pwd)"
+INPUT_ABS="$INPUT_DIR/$(basename "$INPUT")"
+mkdir -p "$OUTDIR"
+
+# Detect logical cores (Linux: nproc; macOS: sysctl) to warn about / handle
+# oversubscription. Open MPI 4.x refuses to launch more ranks than slots unless
+# --oversubscribe is given.
+if command -v nproc >/dev/null 2>&1; then
+    CORES="$(nproc)"
+elif command -v sysctl >/dev/null 2>&1; then
+    CORES="$(sysctl -n hw.logicalcpu 2>/dev/null || echo 0)"
+else
+    CORES=0
+fi
+
+MAX_RANK=0
+for n in "${RANKS[@]}"; do [ "$n" -gt "$MAX_RANK" ] && MAX_RANK="$n"; done
+
+OS_FLAG=""
+if [ "${OVERSUBSCRIBE:-auto}" = "1" ]; then
+    OS_FLAG="--oversubscribe"
+elif [ "${OVERSUBSCRIBE:-auto}" = "auto" ] && [ "$CORES" -gt 0 ] && [ "$MAX_RANK" -gt "$CORES" ]; then
+    echo "[local_sweep] max rank ($MAX_RANK) > cores ($CORES) — enabling --oversubscribe"
+    OS_FLAG="--oversubscribe"
+fi
+
+echo "[local_sweep] ranks=[${RANKS[*]}] steps=$STEPS io=$IO cores=$CORES -> $OUTDIR"
+echo "[local_sweep] input=$INPUT_ABS"
+
+for n in "${RANKS[@]}"; do
+    echo
+    echo "[local_sweep] === ranks=$n ==="
+    # Run from the input's directory so the YAML's relative paths resolve, and
+    # write the JSON record back into the (absolute) OUTDIR.
+    ( cd "$INPUT_DIR" && \
+      "$MPIRUN" -n "$n" $OS_FLAG $MPIRUN_ARGS \
+          "$PYTHON" "$DRIVER" \
+              -i "$INPUT_ABS" --steps "$STEPS" --io "$IO" \
+              --outdir "$OUTDIR" --tag local )
+done
+
+if [ "$ANALYZE" = "1" ]; then
+    echo
+    echo "[local_sweep] analysing -> $ANALYZE_OUT"
+    "$PYTHON" "$ANALYZER" "$OUTDIR" -o "$ANALYZE_OUT"
+else
+    echo
+    echo "[local_sweep] done. Analyse with:"
+    echo "  $PYTHON $ANALYZER $OUTDIR -o $ANALYZE_OUT"
+fi

--- a/scripts/scaling/run_scaling.py
+++ b/scripts/scaling/run_scaling.py
@@ -91,7 +91,18 @@ def main(argv=None):
 
     # ---- bound the run -------------------------------------------------------
     if args.steps and args.steps > 0:
-        model.tEnd = model.tStart + args.steps * model.dt
+        # Cap the run at `steps` timesteps, but never extend past the input's
+        # own end time: the forcing interpolants (sea level, tectonics, rain)
+        # are only defined over the YAML's time range, so running beyond it
+        # raises a scipy "above the interpolation range" ValueError.
+        capped = model.tStart + args.steps * model.dt
+        model.tEnd = min(model.tEnd, capped)
+        if rank == 0 and capped > model.tEnd:
+            print(
+                "[scaling] --steps %d (%.0f) exceeds the input end time; "
+                "capping at tEnd=%.0f" % (args.steps, capped, model.tEnd),
+                flush=True,
+            )
     if args.io == "off":
         # Push every output trigger past the (shortened) end time so visModel
         # and the stratal writer never fire. The single step-0 write that

--- a/scripts/scaling/run_scaling.py
+++ b/scripts/scaling/run_scaling.py
@@ -78,6 +78,22 @@ def main(argv=None):
         default="",
         help="optional label stored in the record (e.g. 'native' / 'container')",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="run the model verbose (per-phase prints + solver monitors, e.g. "
+        "the soil SNES iteration count) — for diagnostics, not timing runs",
+    )
+    parser.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="ATTR=VALUE",
+        help="override a model attribute after construction (repeatable), e.g. "
+        "--set soil_solver=qn --set soil_rtol=1e-4. Values are coerced to "
+        "int/float/bool when possible, else kept as a string. Handy for tuning "
+        "sweeps without editing the YAML.",
+    )
     args = parser.parse_args(argv)
 
     comm = MPI.COMM_WORLD
@@ -86,8 +102,30 @@ def main(argv=None):
 
     # ---- model construction (counts as "init", measured separately) ----------
     t0 = MPI.Wtime()
-    model = Model(args.input, verbose=False, profile=True)
+    model = Model(args.input, verbose=args.verbose, profile=True)
     init_wall = MPI.Wtime() - t0
+
+    # ---- attribute overrides (applied before runProcesses; lazily-built
+    #      solvers such as the soil SNES read these on first use) --------------
+    def _coerce(text):
+        low = text.strip().lower()
+        if low in ("true", "false"):
+            return low == "true"
+        for cast in (int, float):
+            try:
+                return cast(text)
+            except ValueError:
+                pass
+        return text
+
+    for item in args.set:
+        attr, sep, value = item.partition("=")
+        if not sep:
+            raise SystemExit("--set expects ATTR=VALUE, got %r" % item)
+        val = _coerce(value)
+        setattr(model, attr.strip(), val)
+        if rank == 0:
+            print("[scaling] override %s = %r" % (attr.strip(), val), flush=True)
 
     # ---- bound the run -------------------------------------------------------
     if args.steps and args.steps > 0:

--- a/scripts/scaling/run_scaling.py
+++ b/scripts/scaling/run_scaling.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+goSPL parallel-scaling driver.
+
+Runs a goSPL model for a bounded number of timesteps with the wall-clock phase
+profiler enabled, then writes one machine-readable JSON record per MPI rank
+count. Feed several of those records (from runs at different ``mpirun -np``) to
+``analyze_scaling.py`` to get strong-/weak-scaling speedup, efficiency and a
+per-phase breakdown.
+
+Why a dedicated driver (rather than just running the model)?
+  * It **caps the step count** (``--steps``) so a scaling sweep costs a fixed,
+    small amount of compute regardless of the input's ``time:end``.
+  * It can **isolate compute from I/O** (``--io off``) by pushing the output
+    cadence past the (shortened) end time, so the scaling numbers reflect the
+    solver/communication cost, not HDF5 write bandwidth. Run once with
+    ``--io on`` to measure the I/O contribution too.
+  * It records **peak RSS per rank** alongside the timings, so you can see the
+    memory-per-rank trend (the global-array anti-patterns show up here).
+
+Invocation (under mpirun/srun)::
+
+    mpirun -np 8 python run_scaling.py -i input.yml --steps 20 --io off \
+        --outdir scaling_results
+
+Produces ``scaling_results/scaling_p0008.json``.
+
+All ranks participate (the profiler reduction is collective); only rank 0
+writes the JSON.
+"""
+
+import os
+import sys
+import json
+import time
+import argparse
+import platform
+import resource
+
+from mpi4py import MPI
+
+# goSPL writes to the cwd-relative paths in the YAML, so run from the input's
+# directory (the PBS/Slurm wrappers cd there).
+from gospl.model import Model
+
+
+def _peak_rss_mb():
+    """Peak resident set size of this process, in MiB (platform-aware)."""
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # ru_maxrss is bytes on macOS, kibibytes on Linux.
+    if platform.system() == "Darwin":
+        return rss / (1024.0 * 1024.0)
+    return rss / 1024.0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="goSPL scaling driver")
+    parser.add_argument("-i", "--input", required=True, help="goSPL input YAML")
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=20,
+        help="number of timesteps to run (caps tEnd); <=0 runs to the YAML end",
+    )
+    parser.add_argument(
+        "--io",
+        choices=("on", "off"),
+        default="off",
+        help="'off' suppresses per-step HDF5 output to isolate compute",
+    )
+    parser.add_argument(
+        "--outdir",
+        default="scaling_results",
+        help="directory for the scaling_p<N>.json record (rank 0)",
+    )
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="optional label stored in the record (e.g. 'native' / 'container')",
+    )
+    args = parser.parse_args(argv)
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    # ---- model construction (counts as "init", measured separately) ----------
+    t0 = MPI.Wtime()
+    model = Model(args.input, verbose=False, profile=True)
+    init_wall = MPI.Wtime() - t0
+
+    # ---- bound the run -------------------------------------------------------
+    if args.steps and args.steps > 0:
+        model.tEnd = model.tStart + args.steps * model.dt
+    if args.io == "off":
+        # Push every output trigger past the (shortened) end time so visModel
+        # and the stratal writer never fire. The single step-0 write that
+        # `saveTime == tStart` would normally force is also suppressed.
+        big = model.tEnd + abs(model.tEnd) + 1.0e12
+        model.saveTime = big
+        model.saveStrat = big
+
+    # ---- timed run -----------------------------------------------------------
+    comm.Barrier()
+    t0 = MPI.Wtime()
+    model.runProcesses()
+    run_wall = MPI.Wtime() - t0
+
+    # Phase breakdown (collective: every rank calls reduce()).
+    stats = model.profiler.reduce(total_wall=run_wall)
+
+    # Peak memory across ranks.
+    rss = _peak_rss_mb()
+    rss_arr = comm.gather(rss, root=0)
+
+    # Reduce the two wall times to their max (slowest rank governs).
+    run_wall = comm.allreduce(run_wall, op=MPI.MAX)
+    init_wall = comm.allreduce(init_wall, op=MPI.MAX)
+
+    model.destroy()
+
+    if rank == 0:
+        record = {
+            "nranks": size,
+            "input": os.path.abspath(args.input),
+            "steps": args.steps,
+            "io": args.io,
+            "tag": args.tag,
+            "host": platform.node(),
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "init_wall_s": init_wall,
+            "run_wall_s": run_wall,
+            "rss_max_mb_per_rank": max(rss_arr),
+            "rss_sum_mb": sum(rss_arr),
+            "phases": {k: v for k, v in stats.items() if k != "__meta__"},
+        }
+        os.makedirs(args.outdir, exist_ok=True)
+        path = os.path.join(args.outdir, "scaling_p%04d.json" % size)
+        with open(path, "w") as fh:
+            json.dump(record, fh, indent=2)
+        print(
+            "[scaling] P=%d  run=%.2fs  init=%.2fs  rss/rank=%.0fMB  -> %s"
+            % (size, run_wall, init_wall, max(rss_arr), path),
+            flush=True,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scaling/run_scaling.py
+++ b/scripts/scaling/run_scaling.py
@@ -117,8 +117,22 @@ def main(argv=None):
     model.runProcesses()
     run_wall = MPI.Wtime() - t0
 
-    # Phase breakdown (collective: every rank calls reduce()).
-    stats = model.profiler.reduce(total_wall=run_wall)
+    # Phase breakdown (collective: every rank calls reduce()). Tolerate gospl
+    # builds that predate the wall-clock profiler (no `model.profiler`): the
+    # sweep still reports wall time / speedup / RSS, just without the per-phase
+    # split. All ranks run the same build, so this branch is consistent across
+    # the communicator and the collective reduce stays balanced.
+    profiler = getattr(model, "profiler", None)
+    if profiler is not None:
+        stats = profiler.reduce(total_wall=run_wall)
+    else:
+        if rank == 0:
+            print(
+                "[scaling] this gospl build has no wall-clock profiler; "
+                "recording totals only (no per-phase breakdown).",
+                flush=True,
+            )
+        stats = {}
 
     # Peak memory across ranks.
     rss = _peak_rss_mb()

--- a/scripts/scaling/submit_sweep.sh
+++ b/scripts/scaling/submit_sweep.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+###############################################################################
+# Submit a goSPL strong-scaling sweep on NCI Gadi (PBS).
+#
+# qsub's gadi_scaling.pbs once per rank count, overriding ncpus/mem and passing
+# the run parameters via -v. Each job writes scaling_p<N>.json into OUTDIR; once
+# all jobs finish, run analyze_scaling.py on OUTDIR.
+#
+# Usage:
+#   ./submit_sweep.sh /path/to/input.yml [ranks...]
+#
+# Examples:
+#   ./submit_sweep.sh /scratch/q97/me/run/input.yml                 # 1 2 4 8 16 24 48
+#   ./submit_sweep.sh /scratch/q97/me/run/input.yml 2 4 8 16        # custom set
+#
+# Environment overrides:
+#   STEPS   timesteps per run (default 20)
+#   IO      on|off (default off — compute-only)
+#   MODE    native|container (default native)
+#   OUTDIR  results dir (default $PWD/scaling_results)
+#   MEM_PER_CPU_GB  memory request per rank (default 4)
+#   WALLTIME  per-job walltime (default 00:30:00)
+#   CONTAINER  .sif path (MODE=container)
+#   PROJECT  NCI project code for -P (default: from the .pbs file)
+#   QUEUE    PBS queue (default normal)
+#   DEPEND   if set to 1, chain jobs so only one runs at a time (cleaner timing)
+###############################################################################
+set -euo pipefail
+
+INPUT="${1:?usage: submit_sweep.sh <input.yml> [ranks...]}"
+shift || true
+RANKS=("${@:-1 2 4 8 16 24 48}")
+# When no ranks were passed, the default above is a single word; re-split it.
+if [ "${#RANKS[@]}" -eq 1 ]; then
+    read -r -a RANKS <<< "${RANKS[0]}"
+fi
+
+STEPS="${STEPS:-20}"
+IO="${IO:-off}"
+MODE="${MODE:-native}"
+OUTDIR="${OUTDIR:-$PWD/scaling_results}"
+MEM_PER_CPU_GB="${MEM_PER_CPU_GB:-4}"
+WALLTIME="${WALLTIME:-00:30:00}"
+QUEUE="${QUEUE:-normal}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PBS="$HERE/gadi_scaling.pbs"
+
+mkdir -p "$OUTDIR"
+INPUT_ABS="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
+
+echo "Sweep: ranks=[${RANKS[*]}] steps=$STEPS io=$IO mode=$MODE -> $OUTDIR"
+
+prev_job=""
+for n in "${RANKS[@]}"; do
+    mem=$(( n * MEM_PER_CPU_GB ))
+    vargs="NCPUS=$n,INPUT=$INPUT_ABS,STEPS=$STEPS,IO=$IO,MODE=$MODE,OUTDIR=$OUTDIR"
+    [ -n "${CONTAINER:-}" ] && vargs="$vargs,CONTAINER=$CONTAINER"
+    [ -n "${GOSPL_VENV:-}" ] && vargs="$vargs,GOSPL_VENV=$GOSPL_VENV"
+
+    qsub_args=(-q "$QUEUE" -l "ncpus=$n" -l "mem=${mem}GB"
+               -l "walltime=$WALLTIME" -v "$vargs" -N "gospl_p${n}")
+    [ -n "${PROJECT:-}" ] && qsub_args+=(-P "$PROJECT")
+    if [ "${DEPEND:-0}" = "1" ] && [ -n "$prev_job" ]; then
+        qsub_args+=(-W "depend=afterany:$prev_job")
+    fi
+
+    jobid=$(qsub "${qsub_args[@]}" "$PBS")
+    echo "  ranks=$n  mem=${mem}GB  job=$jobid"
+    prev_job="$jobid"
+done
+
+echo
+echo "When all jobs finish:"
+echo "  python $HERE/analyze_scaling.py $OUTDIR -o results/scaling"

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for the wall-clock phase profiler (gospl/tools/profiler.py).
+
+These guard the no-op-when-disabled contract and the accumulation / cross-rank
+reduction math. They run single-rank (the cross-rank Allreduce in a size-1
+communicator is the identity, so the reported min == mean == max), which is
+enough to lock down the reporting arithmetic; true multi-rank imbalance is
+exercised by the scaling harness on HPC, not in the fast tier.
+"""
+
+import json
+
+import pytest
+
+from gospl.tools.profiler import Profiler
+
+
+def test_disabled_is_noop(tmp_path):
+    """A disabled profiler records nothing and never communicates."""
+    p = Profiler(enabled=False)
+    with p.phase("flow"):
+        pass
+    p.start("erosion")
+    p.stop("erosion")
+    assert p.times == {}
+    assert p.counts == {}
+    assert p.reduce(total_wall=1.0) is None
+    assert p.report(outputDir=str(tmp_path), total_wall=1.0) is None
+    # No file written when disabled.
+    assert not (tmp_path / "profile.json").exists()
+
+
+def test_accumulation_counts_and_order():
+    """Repeated phases accumulate time and call counts; order is first-seen."""
+    p = Profiler(enabled=True)
+    for _ in range(3):
+        with p.phase("flow"):
+            pass
+    with p.phase("erosion"):
+        pass
+    assert p.counts["flow"] == 3
+    assert p.counts["erosion"] == 1
+    assert p._order == ["flow", "erosion"]
+    # Manual accumulation path (start/stop) charges the same bucket.
+    p.start("flow")
+    p.stop("flow")
+    assert p.counts["flow"] == 4
+
+
+def test_reduce_math_single_rank():
+    """On one rank, min == mean == max == sum and imbalance == 1.0."""
+    p = Profiler(enabled=True)
+    # Inject deterministic timings instead of sleeping (fast + stable).
+    p._accumulate("flow", 0.4)
+    p._accumulate("flow", 0.2)
+    p._accumulate("erosion", 0.1)
+    stats = p.reduce(total_wall=1.0)
+    assert stats["__meta__"]["nranks"] == 1
+    assert stats["__meta__"]["total_wall"] == pytest.approx(1.0)
+    f = stats["flow"]
+    assert f["calls"] == 2
+    assert f["sum"] == pytest.approx(0.6)
+    assert f["mean"] == pytest.approx(0.6)
+    assert f["min"] == pytest.approx(0.6)
+    assert f["max"] == pytest.approx(0.6)
+    assert f["imbalance"] == pytest.approx(1.0)
+    # A never-recorded phase has zero mean and zero (not NaN) imbalance.
+    p2 = Profiler(enabled=True)
+    p2._accumulate("x", 0.0)
+    assert p2.reduce()["x"]["imbalance"] == 0.0
+
+
+def test_report_writes_json(tmp_path):
+    """report() writes a machine-readable profile.json consumed by the harness."""
+    p = Profiler(enabled=True)
+    p._accumulate("flow", 0.5)
+    p._accumulate("sea", 0.3)
+    p.report(outputDir=str(tmp_path), total_wall=1.0, to_stdout=False)
+    path = tmp_path / "profile.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert set(data.keys()) == {"__meta__", "flow", "sea"}
+    assert data["__meta__"]["nranks"] == 1
+    assert data["flow"]["mean"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

Measure-first parallel-performance tooling for goSPL: instrumentation + an HPC scaling harness to characterise scaling before optimising, plus one safe I/O win. No compute-path algorithm changes — behaviour is byte-compatible when the new options are off.

## What's in it

**Wall-clock phase profiler** (`gospl/tools/profiler.py`)
- The existing per-phase timing uses `process_time()` (per-process **CPU** time), which hides MPI wait time and load imbalance — the wrong clock for parallel runs. The new `Profiler` uses `MPI.Wtime()`.
- No-op (zero overhead) when disabled; the `with` blocks return a shared `nullcontext`.
- `report()` reduces **min/mean/max + imbalance (max/mean)** across ranks, prints a sorted table on rank 0, and writes a machine-readable `profile.json`.
- Wired into `Model.runProcesses` (phases: `tectonics, ice, flow, erosion, till, sed, sea, hillslope, strat, flexure, forcing, output`). Enabled via `Model(..., profile=True)` or YAML `output: profile: true`.
- PETSc `Log` (KSP/SNES/TS solver timings) dumped at `destroy()` when `showlog=True`.

**Gadi PBS scaling harness** (`scripts/scaling/`)
- `run_scaling.py` — capped-step driver, `--io on/off` to isolate compute from HDF5, records peak RSS/rank, writes `scaling_p<N>.json`.
- `gadi_scaling.pbs` (native modules **and** Singularity container), `submit_sweep.sh` (qsub sweep 1→48 ranks), `analyze_scaling.py` (speedup/efficiency + per-phase + RSS plots, CSV, Markdown), `README.md`.

**Configurable output compression** (`gospl/tools/outmesh.py`)
- `output: compression: gzip | <0-9> | none`; default keeps the historical gzip behaviour (byte-compatible). gzip is CPU-serial per dataset and can dominate I/O at scale.

## Bottleneck assessment (from the code audit)

- **Global-array `Allreduce(MAX)` over `mpoints`** — `applyFlexure`/`cptOrography` (every step), `seaplex._matOcean` (every step, seaDepo), `tectonics._advectPlates` (4× when advection fires). O(N_global) memory + comm per rank.
- **Serial rank-0 sections** — pit-filling spillover graph (inside every `flowAccumulation`), flexure/orography solves (gFlex/pyshtools are serial).
- **Ad-hoc fieldsplit KSPs created+destroyed every step** (`eroder/SPL.py`, `seaplex.py`).
- **Flow KSP `rtol=1e-10`** — possibly over-converged for a discharge proxy.

These are staged as **Pass-2** optimisations, each to be prioritised from the profiler data and gated behind `test_parallel_correctness` + `test_mass_conservation`.

## Testing

- `pytest tests/` → **62 passed, 1 skipped** (58 baseline + 4 new profiler tests in `tests/test_profiler.py`); `test_parallel_correctness` and `test_mass_conservation` green.
- 2-rank profiled run confirms cross-rank reduction + per-phase imbalance reporting.
- Harness validated end-to-end locally (run at 1/2 ranks → analyze → CSV/MD/plots).

## How to use on Gadi

Edit the project/venv/storage lines in `scripts/scaling/gadi_scaling.pbs`, then on a production-resolution input:

```bash
PROJECT=q97 GOSPL_VENV=$HOME/envi_gospl/bin/activate \
  ./scripts/scaling/submit_sweep.sh /scratch/q97/$USER/run/input.yml 1 2 4 8 16 24 48
python scripts/scaling/analyze_scaling.py /scratch/q97/$USER/run/scaling_results -o results/scaling
```