### PR TITLE
fix(flow): shift zero pivots in flow-accumulation KSP sub-PCs at scale

### DIFF
--- a/gospl/eroder/SPL.py
+++ b/gospl/eroder/SPL.py
@@ -200,7 +200,8 @@ class SPL(object):
             KSPReasons = self._make_reasons(petsc4py.PETSc.KSP.ConvergedReason())
             if MPIrank == 0:
                 print(
-                    "LinearSolver failed to converge after iterations",
+                    "Detachment-limited SPL KSP (TFQMR/fieldsplit) failed to "
+                    "converge after iterations",
                     ksp.getIterationNumber(),
                     flush=True,
                 )

--- a/gospl/flow/flowplex.py
+++ b/gospl/flow/flowplex.py
@@ -125,6 +125,10 @@ class FAMesh(object):
             ksp.getPC().setType("asm")
             ksp.setTolerances(rtol=1.0e-6, divtol=1.e20)
             ksp.setInitialGuessNonzero(True)
+            # Same zero-pivot guard for the ASM sub-solver (see _solve_KSP).
+            ksp.setOptionsPrefix("flowaccfb_")
+            petsc4py.PETSc.Options()["flowaccfb_sub_pc_factor_shift_type"] = "nonzero"
+            ksp.setFromOptions()
             self._ksp_fallback = ksp
 
         ksp = self._ksp_fallback
@@ -135,7 +139,8 @@ class FAMesh(object):
             KSPReasons = self._make_reasons(petsc4py.PETSc.KSP.ConvergedReason())
             if MPIrank == 0:
                 print(
-                    "LinearSolver failed to converge after iterations",
+                    "Flow-accumulation KSP (fgmres/asm fallback) failed to "
+                    "converge after iterations",
                     ksp.getIterationNumber(),
                     flush=True,
                 )
@@ -170,6 +175,13 @@ class FAMesh(object):
             ksp.setType("richardson")
             ksp.getPC().setType("bjacobi")
             ksp.setTolerances(rtol=self.rtol)
+            # Shift zero/negative pivots in the per-rank ILU sub-solver so the
+            # block-Jacobi PCSetUp cannot fail (DIVERGED_PCSETUP_FAILED) on a
+            # degenerate / ocean-only partition at higher rank counts. Scoped
+            # by an options prefix so it touches only this solver.
+            ksp.setOptionsPrefix("flowacc_")
+            petsc4py.PETSc.Options()["flowacc_sub_pc_factor_shift_type"] = "nonzero"
+            ksp.setFromOptions()
             self._ksp_main = ksp
 
         ksp = self._ksp_main


### PR DESCRIPTION
## Problem
At higher MPI rank counts a rank can receive a degenerate / ocean-only partition whose local block makes the flow-accumulation KSP's per-rank ILU sub-solver (`bjacobi` primary, `asm` fallback) hit a zero pivot. `PCSetUp` then fails (`DIVERGED_PCSETUP_FAILED`, 0 iterations) and the flow solve falls through to a zero-discharge step — non-fatal but it silently corrupts that step's flow and erosion. Observed at np=2 on a 10 km global soil model.

## Fix
Add `pc_factor_shift_type nonzero` to both flow-KSP sub-solvers (scoped by per-KSP option prefixes `flowacc_` / `flowaccfb_`) so the factorisation shifts the zero pivot instead of failing. Also name the solver in the divergence messages (flow-accumulation vs detachment-limited SPL) so a future failure is unambiguous.

## Validation
`test_parallel_correctness` (rel_sum_fa < 5e-2) + full suite pass; flow-accumulation results unchanged.