### PR TITLE
perf(soil): robust soil SNES solver (qn default) + no soil underwater

### DIFF
--- a/docs/user_guide/surfproc.rst
+++ b/docs/user_guide/surfproc.rst
@@ -346,7 +346,18 @@ Soil production, erosion, transport and deposition
         .. important::
 
             When defining a soil thickness grid, one needs to use the **npz** format and needs to specify the key corresponding to the soil thickness value in the file. In the above example this key is ``'soil'``. The soil grid needs to define values for all vertices in the mesh in metres.
-            
+
+        The soil-aware non-linear SPL is solved with a PETSc ``SNES``. Its
+        behaviour can be tuned (all optional) with:
+
+        i. ``maxIter`` is the maximum number of non-linear iterations (default ``500``),
+        j. ``rtol`` / ``atol`` are the relative / absolute convergence tolerances (default ``1.e-6``),
+        k. ``pcType`` is the preconditioner for the Krylov solve (default ``'hypre'`` BoomerAMG; ``'gamg'``, ``'bjacobi'`` or ``'asm'`` can help on heavily-decomposed / ocean-dominated partitions).
+
+        .. note::
+
+            The primary solver is a Nonlinear GMRES accelerator (``ngmres``) right-preconditioned by Nonlinear Richardson (``nrichardson``); if it stalls on a stiff soil-production residual, goSPL automatically retries that timestep with a more robust limited-memory quasi-Newton (L-BFGS) fallback before continuing.
+
 
 Sediment surface erodibility factor
 -------------------------------------

--- a/docs/user_guide/surfproc.rst
+++ b/docs/user_guide/surfproc.rst
@@ -352,11 +352,16 @@ Soil production, erosion, transport and deposition
 
         i. ``maxIter`` is the maximum number of non-linear iterations (default ``500``),
         j. ``rtol`` / ``atol`` are the relative / absolute convergence tolerances (default ``1.e-6``),
-        k. ``pcType`` is the preconditioner for the Krylov solve (default ``'hypre'`` BoomerAMG; ``'gamg'``, ``'bjacobi'`` or ``'asm'`` can help on heavily-decomposed / ocean-dominated partitions).
+        k. ``pcType`` is the preconditioner for the ``ngmres`` Krylov solve (default ``'hypre'`` BoomerAMG; ``'gamg'``, ``'bjacobi'`` or ``'asm'`` can help on heavily-decomposed / ocean-dominated partitions),
+        l. ``solver`` selects the primary non-linear solver: ``'qn'`` (default, limited-memory quasi-Newton / L-BFGS) or ``'ngmres'`` (accelerator + multigrid preconditioner).
+
+        .. tip::
+
+            The soil solve is usually the dominant cost of a soil-enabled run. The default ``solver: 'qn'`` was chosen because on a global model it cut the soil-solve wall time roughly in half (or more) versus ``'ngmres'`` at the **same** tolerance and solution — L-BFGS reaches a comparable iteration count but each iteration is far cheaper than an ``ngmres``/multigrid sweep. If ``'qn'`` struggles on a particular configuration, set ``solver: 'ngmres'``. Prefer switching ``solver`` over relaxing ``rtol``: a loose ``rtol`` can leave the elevation field under-resolved and **destabilise the downstream sediment-routing solver**, which is both slower and less accurate.
 
         .. note::
 
-            The primary solver is a Nonlinear GMRES accelerator (``ngmres``) right-preconditioned by Nonlinear Richardson (``nrichardson``); if it stalls on a stiff soil-production residual, goSPL automatically retries that timestep with a more robust limited-memory quasi-Newton (L-BFGS) fallback before continuing.
+            If the chosen primary solver stalls on a stiff soil-production residual, goSPL automatically retries that timestep with the *complementary* solver (quasi-Newton ⇄ ``ngmres`` multigrid accelerator) at a relaxed tolerance before continuing.
 
 
 Sediment surface erodibility factor

--- a/gospl/eroder/soilSPL.py
+++ b/gospl/eroder/soilSPL.py
@@ -39,6 +39,7 @@ class soilSPL(object):
         self.soil_atol = getattr(self, "soil_atol", 1.0e-6)
         self.soil_maxit = getattr(self, "soil_maxit", 500)
         self.soil_pc = getattr(self, "soil_pc", "hypre")
+        self.soil_solver = getattr(self, "soil_solver", "qn")
 
         # Cached SNES + helper vectors for the soil-aware SPL solver; created
         # lazily on first call and reused across timesteps.
@@ -195,9 +196,24 @@ class soilSPL(object):
             snes.setMonitor(self._monitorsoil)
 
         if primary:
-            snes.setOptionsPrefix("soilspl_")
+            prefix = "soilspl_"
+            solver = self.soil_solver
             snes.setTolerances(rtol=self.soil_rtol, atol=self.soil_atol,
                                max_it=self.soil_maxit)
+        else:
+            prefix = "soilsplfb_"
+            # The fallback only runs when the primary has already stalled, so
+            # use the *other* method (the two are complementary: a fast
+            # quasi-Newton vs the globally-convergent multigrid-preconditioned
+            # accelerator), with a relaxed relative tolerance and a larger
+            # iteration budget as a last resort.
+            solver = "ngmres" if self.soil_solver == "qn" else "qn"
+            snes.setTolerances(rtol=max(self.soil_rtol * 100.0, 1.0e-4),
+                               atol=self.soil_atol,
+                               max_it=max(2 * self.soil_maxit, 200))
+        snes.setOptionsPrefix(prefix)
+
+        if solver == "ngmres":
             snes.setType("ngmres")
             # Nonlinear right-preconditioner: one Richardson sweep per outer
             # iteration is what engages the Krylov solve + multigrid PC.
@@ -213,17 +229,14 @@ class soilSPL(object):
                 pc.setFromOptions()
             ksp.setTolerances(rtol=1.0e-6)
         else:
-            snes.setOptionsPrefix("soilsplfb_")
-            # Relax the relative tolerance and grant a larger iteration budget:
-            # the fallback only runs when the primary has already stalled.
-            snes.setTolerances(rtol=max(self.soil_rtol * 100.0, 1.0e-4),
-                               atol=self.soil_atol,
-                               max_it=max(2 * self.soil_maxit, 200))
-            snes.setType("qn")
-            opts["soilsplfb_snes_qn_type"] = "lbfgs"
-            # Critical-point line search: robust and matrix-free (the 'bt'
+            # Limited-memory quasi-Newton (L-BFGS): builds curvature from secant
+            # updates (no analytic Jacobian) and typically converges in far
+            # fewer iterations than the ngmres accelerator on this stiff
+            # residual. Critical-point line search is matrix-free (the 'bt'
             # backtracking search requires a Jacobian, which qn does not form).
-            opts["soilsplfb_snes_linesearch_type"] = "cp"
+            snes.setType("qn")
+            opts[prefix + "snes_qn_type"] = "lbfgs"
+            opts[prefix + "snes_linesearch_type"] = "cp"
 
         snes.setFromOptions()
         return snes, f

--- a/gospl/eroder/soilSPL.py
+++ b/gospl/eroder/soilSPL.py
@@ -32,15 +32,24 @@ class soilSPL(object):
         Initialisation of `soilSPL` class.
         """
 
-        self.soil_rtol = 1.0e-6
-        self.soil_atol = 1.e-6
-        self.soil_maxit = 100
+        # Soil-SPL SNES controls. These are normally set from the YAML soil
+        # block by the input parser; fall back to robust defaults when soilSPL
+        # is built standalone (e.g. unit tests).
+        self.soil_rtol = getattr(self, "soil_rtol", 1.0e-6)
+        self.soil_atol = getattr(self, "soil_atol", 1.0e-6)
+        self.soil_maxit = getattr(self, "soil_maxit", 500)
+        self.soil_pc = getattr(self, "soil_pc", "hypre")
 
         # Cached SNES + helper vectors for the soil-aware SPL solver; created
         # lazily on first call and reused across timesteps.
         self._snes_soil = None
         self._snes_soil_f = None
         self._snes_soil_x = None
+
+        # Robustness fallback SNES (L-BFGS quasi-Newton); created lazily and
+        # only used on timesteps where the primary solver fails to converge.
+        self._snes_soil_fb = None
+        self._snes_soil_fb_f = None
 
         # Cached TS for the non-linear soil diffusion (rosw scheme); created
         # lazily on first call and reused across timesteps.
@@ -150,6 +159,75 @@ class soilSPL(object):
         if MPIrank == 0 and its % 10 == 0:
             print(f"  ---  Non-linear soil SPL solver iteration {its}, Residual norm: {norm}", flush=True)
 
+    def _build_soil_snes(self, primary=True):
+        """
+        Construct (and return) a soil-SPL SNES solver and its residual vector.
+
+        Two configurations are available:
+
+        * **primary** (``primary=True``) -- a Nonlinear GMRES accelerator
+          (``ngmres``) right-preconditioned by Nonlinear Richardson
+          (``nrichardson``). The Richardson sweep is what actually applies the
+          Krylov solve (``cg``) and the multigrid preconditioner (HYPRE
+          BoomerAMG by default, or ``self.soil_pc``); a *bare* ``ngmres`` ignores
+          the KSP/PC entirely, which is why the previous setup stalled to
+          ``SNES_DIVERGED_MAX_IT`` on the stiff soil-production residual.
+        * **fallback** (``primary=False``) -- a limited-memory quasi-Newton
+          solver (``qn``, L-BFGS) with a matrix-free critical-point line search.
+          It builds an approximate Jacobian from secant updates (no analytic
+          Jacobian required) and is markedly more robust for stiff problems; it
+          runs only when the primary solver fails to converge.
+
+        Each SNES gets its own PETSc options prefix so per-solver options (e.g.
+        the line-search type) do not leak into the model's other SNES/KSP
+        objects.
+
+        :arg primary: select the primary (True) or fallback (False) solver.
+
+        :return: the configured ``(SNES, residual Vec)`` pair.
+        """
+
+        opts = petsc4py.PETSc.Options()
+        snes = petsc4py.PETSc.SNES().create(comm=petsc4py.PETSc.COMM_WORLD)
+        f = self.hGlobal.duplicate()
+        snes.setFunction(self._form_residual_soil, f)
+        if self.verbose:
+            snes.setMonitor(self._monitorsoil)
+
+        if primary:
+            snes.setOptionsPrefix("soilspl_")
+            snes.setTolerances(rtol=self.soil_rtol, atol=self.soil_atol,
+                               max_it=self.soil_maxit)
+            snes.setType("ngmres")
+            # Nonlinear right-preconditioner: one Richardson sweep per outer
+            # iteration is what engages the Krylov solve + multigrid PC.
+            npc = snes.getNPC()
+            npc.setType("nrichardson")
+            npc.setTolerances(max_it=1)
+            ksp = npc.getKSP()
+            ksp.setType("cg")
+            pc = ksp.getPC()
+            pc.setType(self.soil_pc)
+            if self.soil_pc == "hypre":
+                opts["pc_hypre_type"] = "boomeramg"
+                pc.setFromOptions()
+            ksp.setTolerances(rtol=1.0e-6)
+        else:
+            snes.setOptionsPrefix("soilsplfb_")
+            # Relax the relative tolerance and grant a larger iteration budget:
+            # the fallback only runs when the primary has already stalled.
+            snes.setTolerances(rtol=max(self.soil_rtol * 100.0, 1.0e-4),
+                               atol=self.soil_atol,
+                               max_it=max(2 * self.soil_maxit, 200))
+            snes.setType("qn")
+            opts["soilsplfb_snes_qn_type"] = "lbfgs"
+            # Critical-point line search: robust and matrix-free (the 'bt'
+            # backtracking search requires a Jacobian, which qn does not form).
+            opts["soilsplfb_snes_linesearch_type"] = "cp"
+
+        snes.setFromOptions()
+        return snes, f
+
     def _solveSoil(self):
         """
         Solves the non-linear stream power law for the transport limited and soil case. This calls the following *private function*:
@@ -158,7 +236,7 @@ class soilSPL(object):
 
         .. note::
 
-            PETSc SNES approach is used to solve the nonlinear equation. In this implementation of the SNES, we do not form the Jacobian and PETSc calculates it based on the residual function. A Nonlinear Generalized Minimum Residual method is used ``ngmres``, a Preconditioned Conjugate Gradient ``cg`` method is defined for the KSP and the preconditioner allows for multi-grid methods based on the HYPRE BoomerAMG approach.
+            PETSc SNES approach is used to solve the nonlinear equation without forming an analytic Jacobian. The primary solver is a Nonlinear GMRES accelerator (``ngmres``) right-preconditioned by Nonlinear Richardson (``nrichardson``), whose Krylov solve uses a Preconditioned Conjugate Gradient (``cg``) method with a multi-grid preconditioner (HYPRE BoomerAMG by default). If the primary solver stalls on the stiff soil-production residual, a limited-memory quasi-Newton fallback (``qn``, L-BFGS) with a critical-point line search is used. The iteration budget, tolerances and preconditioner are configurable through the YAML ``soil`` block (``maxIter``, ``rtol``, ``atol``, ``pcType``).
         """
 
         self.hOldArray = self.hLocal.getArray().copy()
@@ -203,42 +281,55 @@ class soilSPL(object):
             self.fDep[self.idBorders] = 0.
 
         if self._snes_soil is None:
-            snes = petsc4py.PETSc.SNES().create(comm=petsc4py.PETSc.COMM_WORLD)
-            snes.setTolerances(rtol=self.soil_rtol, atol=self.soil_atol,
-                               max_it=self.soil_maxit)
-            if self.verbose:
-                snes.setMonitor(self._monitorsoil)
-            self._snes_soil_f = self.hGlobal.duplicate()
-            snes.setFunction(self._form_residual_soil, self._snes_soil_f)
-            snes.setType('ngmres')
-            ksp = snes.getKSP()
-            ksp.setType("cg")
-            pc = ksp.getPC()
-            pc.setType("hypre")
-            petsc_options = petsc4py.PETSc.Options()
-            petsc_options['pc_hypre_type'] = 'boomeramg'
-            ksp.getPC().setFromOptions()
-            ksp.setTolerances(rtol=1.0e-6)
+            self._snes_soil, self._snes_soil_f = self._build_soil_snes(primary=True)
             self._snes_soil_x = self.hGlobal.duplicate()
-            self._snes_soil = snes
 
         snes = self._snes_soil
         x = self._snes_soil_x
         self.hGlobal.copy(result=x)
         snes.solve(None, x)
         r = snes.getConvergedReason()
-        if r < 0 and MPIrank == 0:
-            print(
-                "Soil SPL SNES failed to converge after %d iterations (reason %d)"
-                % (snes.getIterationNumber(), r),
-                flush=True,
-            )
+
+        # Robustness net (mirrors the flow KSP's primary -> fallback path): if
+        # the accelerated fixed-point solver stalls (typically
+        # SNES_DIVERGED_MAX_IT on the stiff soil-production residual), retry
+        # from the same initial guess with the limited-memory quasi-Newton
+        # fallback. It only runs on the timesteps where the primary failed.
+        if r < 0:
+            if self._snes_soil_fb is None:
+                self._snes_soil_fb, self._snes_soil_fb_f = self._build_soil_snes(
+                    primary=False
+                )
+            fb = self._snes_soil_fb
+            r0, it0 = r, snes.getIterationNumber()
+            self.hGlobal.copy(result=x)
+            fb.solve(None, x)
+            r = fb.getConvergedReason()
+            if MPIrank == 0:
+                if r >= 0:
+                    print(
+                        "Soil SPL: primary SNES stalled (reason %d after %d its); "
+                        "quasi-Newton fallback converged (reason %d, %d its)."
+                        % (r0, it0, r, fb.getIterationNumber()),
+                        flush=True,
+                    )
+                else:
+                    print(
+                        "Soil SPL SNES failed to converge: primary (reason %d) and "
+                        "quasi-Newton fallback (reason %d) both diverged; continuing "
+                        "with the best available iterate." % (r0, r),
+                        flush=True,
+                    )
 
         # Get eroded sediment thicknesses
         self.tmp.waxpy(-1.0, self.hOld, x)
 
         # Update soil thicknesses
         nHsoil = self.nsoilH.copy()
+        # No subaerial soil production underwater: the soil-production term
+        # scales with rainfall (Norton et al. 2013), so without this mask the
+        # submarine nodes accumulate a spurious rainfall-scaled soil cover.
+        nHsoil[self.seaID] = 0.0
         nHsoil[nHsoil < BEDROCK_EXPOSED] = 0.
         # Limit soil thickness
         nHsoil[nHsoil > self.soil_transition] = self.soil_transition

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -594,6 +594,11 @@ class ReadYaml(object):
             # Preconditioner for the soil SNES Krylov solve: 'hypre'
             # (BoomerAMG, default), 'gamg', 'bjacobi', 'asm', ...
             self.soil_pc = str(soilDict.get("pcType", "hypre"))
+            # Primary nonlinear solver: 'qn' (limited-memory quasi-Newton /
+            # L-BFGS, default — ~2.4x faster than ngmres at the same tolerance
+            # and solution on a global soil model) or 'ngmres' (accelerator +
+            # multigrid PC). Whichever is chosen, the other is the fallback.
+            self.soil_solver = str(soilDict.get("solver", "qn"))
 
         except KeyError:
             self.cptSoil = False
@@ -614,6 +619,7 @@ class ReadYaml(object):
             self.soil_rtol = 1.0e-6
             self.soil_atol = 1.0e-6
             self.soil_pc = "hypre"
+            self.soil_solver = "qn"
 
         return
 

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -583,6 +583,18 @@ class ReadYaml(object):
             # Reference temperature in Celsius
             self.tempRef = soilDict.get("tempRef", 15.0)
 
+            # Soil-SPL nonlinear-solver (SNES) controls. The soil-aware SPL
+            # residual is stiffer than the bedrock case (soil-production
+            # coupling), so the iteration budget defaults to the same value as
+            # nlSPL (500, up from the previous 100) and the tolerances and
+            # preconditioner are exposed for tuning at scale.
+            self.soil_maxit = int(soilDict.get("maxIter", 500))
+            self.soil_rtol = float(soilDict.get("rtol", 1.0e-6))
+            self.soil_atol = float(soilDict.get("atol", 1.0e-6))
+            # Preconditioner for the soil SNES Krylov solve: 'hypre'
+            # (BoomerAMG, default), 'gamg', 'bjacobi', 'asm', ...
+            self.soil_pc = str(soilDict.get("pcType", "hypre"))
+
         except KeyError:
             self.cptSoil = False
             self.Ksoil = 0.0
@@ -598,6 +610,10 @@ class ReadYaml(object):
             self.tempRef = 15.0
             self.tempFile = None
             self.tempData = None
+            self.soil_maxit = 500
+            self.soil_rtol = 1.0e-6
+            self.soil_atol = 1.0e-6
+            self.soil_pc = "hypre"
 
         return
 


### PR DESCRIPTION
Stacks on #444 (base `fix/soil-temp-parallel-shape`; retarget to `dev` once #444 merges).

## What
Makes the soil-aware SPL SNES converge reliably **and** fast, and fixes a soil-thickness output bug.

### Convergence + robustness
The previous solver was a bare `ngmres` accelerator, which ignores its configured cg/hypre KSP (no nonlinear preconditioner) and stalled to `SNES_DIVERGED_MAX_IT` on the stiff soil-production residual — reproducible even at np=1; the 100-iter cap was also half nlSPL's 500. Now: a configurable primary solver with a **complementary fallback** (qn ⇄ ngmres/multigrid) so the net always tries two distinct methods.

### Performance (qn default)
Benchmarking a 10 km global soil model: `solver: 'qn'` (L-BFGS) is **~2.4× faster** than ngmres (total step 77 s → 32 s) at the **same** tolerance and solution (marine excess matches to 5 digits). L-BFGS needs a similar iteration count but each iteration is far cheaper than an ngmres/multigrid sweep. Made the default.

### Correctness
Force `soilH = 0` at submarine nodes — the rainfall-scaled soil-production term was accumulating a spurious soil cover underwater.

### Tunables (YAML `soil:`)
`maxIter`, `rtol`, `atol`, `pcType`, `solver`. Docs updated; warns that loosening `rtol` can destabilise the downstream sediment-routing solver (observed), so prefer `solver: 'qn'`.

## Validation
Full suite 59 passed / 1 skipped; `test_soil_temp_parallel_shape` (mpirun -n 2) passes; qn-primary validated end-to-end and on the real 5.9M-node model at np=1/4/6.