### PR TITLE
perf(seaplex): one-pass CSR build of the ocean flow-direction matrix

### DIFF
--- a/gospl/sed/seaplex.py
+++ b/gospl/sed/seaplex.py
@@ -198,26 +198,31 @@ class SEAMesh(object):
         self.dMat1 = self.zMat.copy()
         if not self.flatModel and self.Gmar > 0.:
             self.dMat2 = self.iMat.copy()
-        indptr = np.arange(0, self.lpoints + 1, dtype=petsc4py.PETSc.IntType)
-        nodes = indptr[:-1]
+        nodes = np.arange(self.lpoints, dtype=petsc4py.PETSc.IntType)
 
-        for k in range(0, 12):
-            # Flow direction matrix for a specific direction
-            tmpMat = self._matrix_build()
-            data = wght[:, k].copy()
-            data[rcv[:, k].astype(petsc4py.PETSc.IntType) == nodes] = 0.0
-            tmpMat.assemblyBegin()
-            tmpMat.setValuesLocalCSR(
-                indptr,
-                rcv[:, k].astype(petsc4py.PETSc.IntType),
-                data,
-            )
-            tmpMat.assemblyEnd()
-            # Add the weights from each direction
-            self.dMat1.axpy(1.0, tmpMat)
-            if not self.flatModel and self.Gmar > 0.:
-                self.dMat2.axpy(-1.0, tmpMat)
-            tmpMat.destroy()
+        # Assemble all 12 flow directions in a single CSR pass instead of 12
+        # build+axpy iterations. ADD_VALUES makes receivers shared by several
+        # directions sum exactly as the per-direction axpy loop did, so the
+        # assembled matrix is identical; this just replaces 12 matrix builds +
+        # 12 sparse axpys (the dominant cost of this step) with one build and
+        # one (or two) axpy.
+        rcvFlat = rcv.astype(petsc4py.PETSc.IntType)
+        data = wght.copy()
+        data[rcvFlat == nodes[:, None]] = 0.0
+        indptr = np.arange(0, self.lpoints * 12 + 1, 12, dtype=petsc4py.PETSc.IntType)
+        offMat = self._matrix_build(nnz=(12, 12))
+        offMat.assemblyBegin()
+        offMat.setValuesLocalCSR(
+            indptr,
+            rcvFlat.ravel(),
+            data.ravel(),
+            addv=petsc4py.PETSc.InsertMode.ADD_VALUES,
+        )
+        offMat.assemblyEnd()
+        self.dMat1.axpy(1.0, offMat)
+        if not self.flatModel and self.Gmar > 0.:
+            self.dMat2.axpy(-1.0, offMat)
+        offMat.destroy()
 
         if self.memclear:
             del data, indptr, nodes


### PR DESCRIPTION
## What
`_matOcean` built the marine downstream matrix `dMat1` by looping over the 12 flow directions, assembling a one-entry-per-row temp matrix and `MatAXPY`-ing it each iteration — **12 matrix builds + 12 sparse axpys** (each merging sparsity patterns), which profiling showed to be the bulk of the 'marine ocean matrix' step's assembly cost.

This assembles all 12 directions in a **single `setValuesLocalCSR` pass** into one preallocated matrix, then `axpy`s once (twice when `Gmar>0`). `ADD_VALUES` makes receivers shared by several directions sum exactly as the per-direction `axpy` loop did.

## Correctness
**Bit-identical** assembled matrix — verified directly: rebuilding `dMat1` the old per-direction way and comparing gave `|new − old|_F = 0.000e+00` on the global fixture (n=1). Full suite **58 passed / 1 skipped**.

## Context
Profiling the `sea` phase (now the dominant phase after the eroder fixes) showed `_matOcean` ≈ 3 s, of which the `_hillSlope(smooth=2)` implicit-diffusion solve is the larger part (PCSetUp-bound — a separate concern, left untouched) and the dMat assembly ≈ 0.8 s. This PR targets the assembly.