### PR TITLE
fix(strat): crash when a node's whole column is eroded (erodeStrat bincount truncation)

### DIFF
--- a/gospl/sed/stratplex.py
+++ b/gospl/sed/stratplex.py
@@ -450,8 +450,20 @@ class STRAMesh(object):
             self.stratP[nids, : self.stratStep + 1, :] = tmpp
 
         # Erode remaining stratal layers
-        # Get non-zero top layer number
-        eroLayNb = np.bincount(np.nonzero(cumThick)[0]) - 1
+        # Get non-zero top layer number. `minlength=len(nids)` is required: a
+        # node whose entire column was consumed (every layer in `boolMask`, i.e.
+        # the erosion demand exceeded the total pile *including* the
+        # BEDROCK_SENTINEL infinite-bedrock floor) contributes no nonzero row to
+        # `np.nonzero(cumThick)[0]`. Without minlength, `bincount` silently
+        # truncates such an all-zero row when it is the LAST node, so `eroLayNb`
+        # comes back one short and the fancy-index below raises a broadcast
+        # IndexError (a middle all-zero row already gets a 0 count, so only
+        # trailing ones crash). The sentinel makes a fully-consumed column
+        # impossible for physical erosion, but a non-converged upstream solve
+        # (e.g. the SIA ice SNES feeding glacial abrasion `dz_ero`) can produce
+        # a pathological demand that reaches here; padding keeps `erodeStrat`
+        # crash-safe and treats those rows like any other fully-eroded node.
+        eroLayNb = np.bincount(np.nonzero(cumThick)[0], minlength=len(nids)) - 1
         eroVal = cumThick[np.arange(len(nids)), eroLayNb] + ero[nids]
 
         self.thCoarse = np.zeros(self.lpoints)


### PR DESCRIPTION
## Bug
`erodeStrat` computed the top remaining stratal layer per node with `np.bincount(np.nonzero(cumThick)[0]) - 1`. When a node's **entire** `cumThick` column is zeroed (erosion demand > the whole pile *including* the `BEDROCK_SENTINEL` infinite-bedrock floor), that row has no nonzero entry, so `bincount` silently **truncates it if it's the last node** — `eroLayNb` comes back one short and the fancy index raises `IndexError: shape mismatch (N,) (N-1,)`. (A *middle* all-zero row already gets a 0 count, so only a trailing one crashed — hence the np>1-only manifestation.)

Reported at np=4 with `ice.till` + dual lithology:
```
File "iceplex.py", _glacialTillStrata -> erodeStrat
IndexError: shape mismatch: ... shapes (1751,) (1750,)
```

## Fix
`minlength=len(nids)` on the `bincount` so `eroLayNb` always matches `nids`; trailing all-zero rows now behave like middle ones (eroLayNb = -1, valid). One-line, no behaviour change for legitimate input (the sentinel means no all-zero rows occur → minlength is a no-op).

## Root cause (separate, not fixed here)
The pathological over-erosion came from a **diverged SIA ice SNES** (`reason -9`) → garbage basal velocity → garbage glacial abrasion `dz_ero`. This PR makes `erodeStrat` crash-safe against it; the SIA divergence itself is the separate ice-solver project (AGENTS "Ice sheet" fragility note).

## Validation
Full suite 63 passed / 1 skipped; strata/till/ice/dual tests green. (The exact trigger needs a diverged-SIA + parallel reproducer — verified by code logic + the reporter's np=4 run.)