### PR TITLE
chore(gitignore): ignore ice fixture output dirs; drop stale SIA entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ tests/fixtures/incising/
 tests/fixtures/minimal_strat/
 tests/fixtures/minimal_dual/
 tests/fixtures/minimal_dual_coarse/
-tests/fixtures/minimal_ice_sia/
+tests/fixtures/minimal_ice/
+tests/fixtures/ice_soil_out/
 tests/fixtures/minimal_ice_till/
 tests/fixtures/minimal_ice_flex/
 tests/fixtures/minimal_ice_dual/
@@ -36,7 +37,3 @@ tests/fixtures/prov_src.npz
 MANIFEST
 .ipynb_checkpoints
 fortran/meshparams.mod
-tests/fixtures/minimal_ice_sia/
-tests/fixtures/minimal_ice_mfd/
-tests/fixtures/minimal_ice_till/
-tests/fixtures/minimal_ice_flex/


### PR DESCRIPTION
## What

- **Add** `tests/fixtures/minimal_ice/` (regenerated from `minimal_ice.yml`) and `tests/fixtures/ice_soil_out/` (from `minimal_ice_soil.yml`) to the regenerated-test-output ignore list — these dirs were being left as untracked goSPL output after running the ice tests.
- **Remove** a duplicated trailing block of `minimal_ice_*` entries and the dead `minimal_ice_sia/` entry left over from the removed SIA model.

## Why

The ice tests write output dirs into `tests/fixtures/` that shouldn't be tracked; they were showing up in `git status`. The SIA fixtures no longer exist (SIA was removed in #454), so their ignore entries are dead.

## Scope

`.gitignore` only (+2/−5). Verified with `git check-ignore` that both new dirs now match.