### PR TITLE
perf(sea): cache the marine flow-direction smoother; make it mesh-based + dt-independent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Rule: use `MPI.COMM_WORLD` for raw collectives (Allreduce/bcast/Allgatherv); use
 ## KSP / SNES / TS lifecycle contract
 PETSc solvers in goSPL follow two intentional patterns. **Use the right one for new code.**
 
-### CACHED — hot-path solvers (8 sites)
+### CACHED — hot-path solvers (9 sites)
 Solvers that run **every timestep** are created lazily on first use, stored as `self._X`, and reused across the entire simulation. Avoids the ~5-10 ms create+destroy churn per call, which compounds over thousands of timesteps. Each site's inline docstring confirms the rationale.
 
 | File | Method | Cached attribute | Solver |
@@ -61,6 +61,7 @@ Solvers that run **every timestep** are created lazily on first use, stored as `
 | `eroder/soilSPL.py` | `diffuseSoil` | `self._ts_soil` | TS (rosw soil diffusion) |
 | `sed/hillslope.py` | `_hillSlopeNL` | `self._snes_hill` | SNES (non-linear hillslope) |
 | `sed/hillslope.py` | `_diffuseImplicit` | `self._ts_marine` | TS (rosw marine + lake diffusion) |
+| `sed/hillslope.py` | `_solveSmooth` | `self._ksp_smooth` (+ cached operator `self._smoothMat`) | KSP (richardson+bjacobi, `marsmooth_` prefix, factor-shift) for the marine flow-direction smoother (`_hillSlope(smooth=2)`). Operator is mesh-size-based + timestep-independent so it is built once and the PC **reused**; rebuilt only when the coastline (`seaID`) moves (`_smooth_pc_ready` guards the reuse). |
 
 **Selectable solver + complementary fallback** (soilSPL `_solveSoil`, nlSPL `_solveNL_ed`): built by a `_build_*_snes(primary=)` helper. The primary defaults to `qn` (L-BFGS + critical-point line search, set via the YAML `solver:` key). A *bare* `ngmres` ignores its configured KSP/PC and **stalls or diverges** on these stiff residuals (this was the historical default; it cost soil ~2.4× and nlSPL-transport ~10×, and diverged outright on the SIA — which is why SIA is now solved explicitly, see "Ice sheet"). On non-convergence the solve retries from the same initial guess with the **complementary** solver (`qn` ⇄ `ngmres`+`nrichardson`+hypre); if both fail it warns and continues with the best iterate (never crashes). Each SNES carries its own options prefix (`soilspl_`/`soilsplfb_`/`nlspled_`/`nlspledfb_`) so line-search options don't leak between solvers. The `_fb` fallback SNES **and** its `_f` residual vec are cached and are in the `destroy_DMPlex` list. YAML knobs (`soil:` / `spl:` blocks): `maxIter`, `rtol`, `atol`, `pcType`, `solver`. **Linear** coupled SPL deposition (`SPL._coupledEDSystem`) instead uses a **Schur-complement** fieldsplit (`spl_ed_` prefix, defaults injected into the options DB guarded by `hasName` so `PETSC_OPTIONS` override) — ~60× fewer Krylov iterations than the old additive split, solution unchanged.
 
@@ -258,6 +259,8 @@ All sentinels and threshold values are defined in `gospl/tools/constants.py` and
 | `BEDROCK_SENTINEL` | `1.0e6` | Infinite-bedrock layer-0 sentinel thickness; offset cancels in cumsum arithmetic. |
 | `BOUNDARY_FLOW_SENTINEL` | `-1.0e6` | Mfd no-data marker passed to `mfdreceivers`/`mfdrcvrs`; **distinct from `MISSING_DATA_SENTINEL`** — kept two orders apart so a mix-up is obvious in diagnostics. |
 | `GRAPH_OUTLIER_CAP` | `1.0e7` | Upper-bound clamp in `pitfilling._performFilling`; entries above this are rewritten to `MISSING_DATA_SENTINEL`. |
+| `MARINE_SMOOTH_N_LAND` | `1.0` | Dimensionless smoothing strength for emergent land in the marine flow-direction smoother (`hillslope._hillSlope(smooth=2)`). |
+| `MARINE_SMOOTH_N_SEA` | `5.0` | Dimensionless smoothing strength for the seafloor in the same smoother (heavier than land). Per-node `Kd = N·cell_area`, so the smoothing is timestep- and resolution-independent (replaces the old `Cd·dt`, `Cd∈{1e5,5e6}` m²/yr, whose effective strength `v≈Cd·dt/Δx²` silently varied with both `dt` and mesh resolution — `~1e-3` on the coarse fixtures, `~55` on a 30 km/`dt=1e4` run). Used only to derive marine flow directions in `seaplex._matOcean`; never alters elevation. |
 
 **Same value, different role — DO NOT replace these with the listed constants:**
 - `1.0e-8` at `sed/stratplex.py:219` (thickness numerical-noise floor).

--- a/gospl/mesher/unstructuredmesh.py
+++ b/gospl/mesher/unstructuredmesh.py
@@ -992,6 +992,7 @@ class UnstMesh(object):
             "_snes_soil_fb", "_snes_soil_fb_f",
             "_snes_hill", "_snes_hill_f", "_snes_hill_x",
             "_ts_marine", "_ts_marine_x",
+            "_smoothMat", "_ksp_smooth",
             "_ts_soil", "_ts_soil_x", "_ts_soil_f",
         ):
             obj = getattr(self, name, None)

--- a/gospl/sed/hillslope.py
+++ b/gospl/sed/hillslope.py
@@ -7,6 +7,8 @@ import numpy as np
 from mpi4py import MPI
 from time import process_time
 
+from gospl.tools.constants import MARINE_SMOOTH_N_LAND, MARINE_SMOOTH_N_SEA
+
 if "READTHEDOCS" not in os.environ:
     from gospl._fortran import sethillslopecoeff
     from gospl._fortran import hillslp_nl
@@ -49,6 +51,17 @@ class hillSLP(object):
         self._ts_marine = None
         self._ts_marine_x = None
 
+        # Cached marine-morphology smoothing operator (_hillSlope smooth=2) and
+        # its KSP. The smoothing diffusivity is mesh-size-based and timestep-
+        # independent, so the operator depends only on the (fixed) mesh and the
+        # land/sea mask; it is built once and reused, and rebuilt only when the
+        # coastline (seaID) moves. _smooth_pc_ready tracks whether the cached
+        # preconditioner is valid for the current operator.
+        self._smoothMat = None
+        self._ksp_smooth = None
+        self._smooth_seaID = None
+        self._smooth_pc_ready = False
+
         return
 
     def _hillSlope(self, smooth=0):
@@ -63,7 +76,20 @@ class hillSLP(object):
         .. note::
             The hillslope processes in goSPL are considered to be happening at the same rate for coarse and fine sediment sizes.
 
-        :arg smooth: integer specifying if the diffusion equation is used to smooth marine deposits (2).
+        :arg smooth: smoothing mode. ``0`` (default) computes linear soil-creep
+            hillslope and updates the elevation in place. ``1`` returns a one-off
+            smoothed copy of the ice-surface proxy used to derive glacial flow
+            directions. ``2`` returns a smoothed bathymetry used **only** to
+            derive coherent marine flow directions in ``_matOcean`` — it never
+            alters the elevation. The ``smooth=2`` operator uses a mesh-size-
+            based, timestep-independent diffusivity (see
+            ``MARINE_SMOOTH_N_*``) and is cached + reused across steps, rebuilt
+            only when the coastline moves.
+
+        .. note::
+            This method uses scratch Vecs ``self.tmp`` / ``self.tmpL`` (and, for
+            ``smooth=1``, ``self.tmp1`` as the input field). ``smooth=0`` also
+            uses ``self.hOld``.
         """
 
         if smooth == 0:
@@ -71,21 +97,96 @@ class hillSLP(object):
                 return
 
         t0 = process_time()
-        # Diffusion matrix construction
+
+        # --- smooth=2: marine-morphology smoothing (flow-direction finding) ---
+        # The diffusivity is mesh-size-based: per-node Kd = N * cell_area, with N
+        # a dimensionless smoothing number (MARINE_SMOOTH_N_*). Because the FV
+        # Laplacian stencil scales as Kd / Δx^2, this is both timestep- and
+        # resolution-independent. The operator then depends only on the fixed
+        # mesh and the land/sea mask, so it is cached and its preconditioner
+        # reused; it is rebuilt only when the coastline (seaID) moves.
         if smooth == 2:
-            # Hard-coded coefficients here, used to generate a smooth surface
-            # for computing marine flow directions...
-            Cd = np.full(self.lpoints, 1.e5, dtype=np.float64)
-            Cd[self.seaID] = 5.e6
-        else:
-            Cd = np.full(self.lpoints, self.Cda, dtype=np.float64)
-            Cd[self.seaID] = self.Cdm
-            # Dual-lithology (Phase 7): scale the diffusivity by the surface
-            # composition so fines diffuse faster (1.0 everywhere when single-
-            # fraction / no contrast, so behaviour is unchanged).
-            if self.stratLith:
-                Cd = Cd * self._surfaceLithoD()
-        diffCoeffs = sethillslopecoeff(self.lpoints, Cd * self.dt)
+            if self._smoothMat is None or not np.array_equal(
+                self.seaID, self._smooth_seaID
+            ):
+                Cd = np.full(self.lpoints, MARINE_SMOOTH_N_LAND, dtype=np.float64)
+                Cd[self.seaID] = MARINE_SMOOTH_N_SEA
+                if self._smoothMat is not None:
+                    self._smoothMat.destroy()
+                self._smoothMat = self._buildDiffMat(Cd * self.larea)
+                self._smooth_seaID = self.seaID.copy()
+                self._smooth_pc_ready = False
+            self._solveSmooth(self.hGlobal, self.tmp)
+            self.dm.globalToLocal(self.tmp, self.tmpL)
+            return self.tmpL.getArray().copy()
+
+        # --- smooth=0 (linear soil creep) / smooth=1 (ice-surface smoothing) ---
+        # The diffusivity is the physical Ka/Km (optionally lithology-scaled),
+        # which can vary each step, so the operator is rebuilt every call.
+        Cd = np.full(self.lpoints, self.Cda, dtype=np.float64)
+        Cd[self.seaID] = self.Cdm
+        # Dual-lithology (Phase 7): scale the diffusivity by the surface
+        # composition so fines diffuse faster (1.0 everywhere when single-
+        # fraction / no contrast, so behaviour is unchanged).
+        if self.stratLith:
+            Cd = Cd * self._surfaceLithoD()
+        diffMat = self._buildDiffMat(Cd * self.dt)
+
+        # Get elevation values for considered time step
+        if smooth == 1:
+            if self.tmp1.max()[1] > 0:
+                self._solve_KSP(True, diffMat, self.tmp1, self.tmp)
+            else:
+                self.tmp1.copy(result=self.tmp)
+            diffMat.destroy()
+            self.dm.globalToLocal(self.tmp, self.tmpL)
+            return self.tmpL.getArray().copy()
+
+        # smooth == 0
+        self.hGlobal.copy(result=self.hOld)
+        self._solve_KSP(True, diffMat, self.hOld, self.hGlobal)
+        diffMat.destroy()
+        # Update cumulative erosion/deposition and elevation
+        self.tmp.waxpy(-1.0, self.hOld, self.hGlobal)
+        self.cumED.axpy(1.0, self.tmp)
+        self.dm.globalToLocal(self.cumED, self.cumEDLocal)
+        self.dm.globalToLocal(self.hGlobal, self.hLocal)
+
+        if self.memclear:
+            del Cd
+            gc.collect()
+
+        if self.stratNb > 0:
+            self.erodeStrat()
+            self.deposeStrat()
+
+        if MPIrank == 0 and self.verbose:
+            print(
+                "Compute Linear Hillslope Processes (%0.02f seconds)" % (process_time() - t0),
+                flush=True,
+            )
+        petsc4py.PETSc.garbage_cleanup()
+
+        return
+
+    def _buildDiffMat(self, Kd):
+        """
+        Assemble the implicit linear-diffusion operator :math:`(I - L)` for the
+        finite-volume Laplacian, given per-node coefficients ``Kd`` (m², i.e. a
+        diffusivity × time, or the mesh-size-based marine-smoothing coefficient
+        ``N · cell_area``).
+
+        Shared by the linear hillslope (``smooth=0``), the ice-surface smoothing
+        (``smooth=1``) and the cached marine-smoothing operator (``smooth=2``).
+
+        :arg Kd: per-node diffusion coefficient array (``lpoints``, m²).
+
+        :return: the assembled PETSc diffusion matrix (caller owns it; the
+            ``smooth=0/1`` callers destroy it after the solve, the ``smooth=2``
+            caller caches it).
+        """
+
+        diffCoeffs = sethillslopecoeff(self.lpoints, Kd)
         if self.flatModel:
             diffCoeffs[self.idBorders, 1:] = 0.0
             diffCoeffs[self.idBorders, 0] = 1.0
@@ -109,43 +210,45 @@ class hillSLP(object):
             diffMat.axpy(1.0, tmpMat)
             tmpMat.destroy()
 
-        # Get elevation values for considered time step
-        if smooth == 1:
-            if self.tmp1.max()[1] > 0:
-                self._solve_KSP(True, diffMat, self.tmp1, self.tmp)
-            else:
-                self.tmp1.copy(result=self.tmp)
-            diffMat.destroy()
-            self.dm.globalToLocal(self.tmp, self.tmpL)
-            return self.tmpL.getArray().copy()
-        elif smooth == 2:
-            self._solve_KSP(True, diffMat, self.hGlobal, self.tmp)
-            diffMat.destroy()
-            self.dm.globalToLocal(self.tmp, self.tmpL)
-            return self.tmpL.getArray().copy()
-        else:
-            self.hGlobal.copy(result=self.hOld)
-            self._solve_KSP(True, diffMat, self.hOld, self.hGlobal)
-            diffMat.destroy()
-            # Update cumulative erosion/deposition and elevation
-            self.tmp.waxpy(-1.0, self.hOld, self.hGlobal)
-            self.cumED.axpy(1.0, self.tmp)
-            self.dm.globalToLocal(self.cumED, self.cumEDLocal)
-            self.dm.globalToLocal(self.hGlobal, self.hLocal)
+        return diffMat
 
-            if self.memclear:
-                del ids, indices, indptr, diffCoeffs, Cd
-                gc.collect()
+    def _solveSmooth(self, rhs, sol):
+        """
+        Solve one implicit step of the cached marine-smoothing diffusion
+        operator (see ``_hillSlope`` ``smooth=2``).
 
-            if self.stratNb > 0:
-                self.erodeStrat()
-                self.deposeStrat()
+        The operator (``self._smoothMat``) is rebuilt only when the coastline
+        moves, so the block-Jacobi/ILU preconditioner is factorised once and
+        **reused** across every step with an unchanged land/sea mask — that
+        factorisation (not the 1-iteration Richardson solve) was the dominant
+        per-step cost of the previous build-from-scratch approach.
 
-        if MPIrank == 0 and self.verbose:
-            print(
-                "Compute Linear Hillslope Processes (%0.02f seconds)" % (process_time() - t0),
-                flush=True,
-            )
+        :arg rhs: PETSc global Vec — the field to smooth (read).
+        :arg sol: PETSc global Vec — the smoothed result (written; scratch
+            ``self.tmp`` at the call site).
+        """
+
+        if self._ksp_smooth is None:
+            ksp = petsc4py.PETSc.KSP().create(petsc4py.PETSc.COMM_WORLD)
+            ksp.setType("richardson")
+            ksp.getPC().setType("bjacobi")
+            ksp.setTolerances(rtol=self.rtol)
+            ksp.setInitialGuessNonzero(True)
+            # Shift zero/negative ILU pivots so the block-Jacobi PCSetUp cannot
+            # fail on a degenerate / ocean-only partition (mirrors _solve_KSP).
+            ksp.setOptionsPrefix("marsmooth_")
+            petsc4py.PETSc.Options()["marsmooth_sub_pc_factor_shift_type"] = "nonzero"
+            ksp.setFromOptions()
+            self._ksp_smooth = ksp
+
+        ksp = self._ksp_smooth
+        ksp.setOperators(self._smoothMat, self._smoothMat)
+        # Reuse the factorised preconditioner unless the operator was just
+        # rebuilt (coastline moved) — then PCSetUp runs once for the new matrix.
+        # (setReusePreconditioner lives on the PC, not the KSP, in petsc4py.)
+        ksp.getPC().setReusePreconditioner(self._smooth_pc_ready)
+        self._smooth_pc_ready = True
+        ksp.solve(rhs, sol)
         petsc4py.PETSc.garbage_cleanup()
 
         return

--- a/gospl/tools/constants.py
+++ b/gospl/tools/constants.py
@@ -98,3 +98,30 @@ BOUNDARY_FLOW_SENTINEL = -1.0e6
 # see the sentinel-filter comment in pitfilling.py for the full
 # rationale.
 GRAPH_OUTLIER_CAP = 1.0e7
+
+# Dimensionless diffusion numbers for the marine-morphology smoothing used
+# ONLY to derive coherent marine flow directions in sed/seaplex.py::_matOcean
+# (_hillSlope(smooth=2)). This smoothing never alters elevation — it produces a
+# de-noised bathymetry so the multiple-flow-direction kernel routes marine
+# sediment down the large-scale seafloor slope instead of trapping it in small
+# local minima.
+#
+# The smoothing solves one implicit diffusion step (I - L) h_s = h with a
+# per-node coefficient Kd = N * cell_area (m^2). Because the FV Laplacian
+# stencil scales as Kd / Δx^2, folding the cell area into Kd makes N a
+# dimensionless smoothing strength that is BOTH timestep-independent AND
+# mesh-resolution-independent — replacing the former hard-coded Kd = Cd*dt with
+# Cd in {1e5 (land), 5e6 (sea)} m^2/yr, which scaled with dt and with 1/Δx^2 so
+# the effective smoothing silently varied with the timestep and the mesh.
+#
+# The seafloor (SEA) is smoothed more heavily than emergent land (5x here):
+# routing only needs coherent bathymetric directions, while coastal land just
+# needs to stay continuous for the pit-fill + flow-direction pass. These are
+# moderate de-noising strengths (v ~ N per neighbour) — enough to make the
+# seafloor monotone toward sinks without flattening the large-scale slope;
+# increase for stronger smoothing. NB the marine routing (and hence the
+# downstream conservation residual on a coarse mesh) is sensitive to this, so
+# retune against the dual/marine conservation tests if you change it. See
+# AGENTS.md > Magic numbers.
+MARINE_SMOOTH_N_LAND = 1.0
+MARINE_SMOOTH_N_SEA = 5.0


### PR DESCRIPTION
## What

`_hillSlope(smooth=2)` builds a heavily-smoothed bathymetry used **only** to derive marine flow directions in `seaplex._matOcean` (it never alters elevation). It was rebuilt and re-factorised every marine step even though it depends only on the **fixed** mesh geometry and the land/sea mask — profiled at **~2 s/step** (build 0.57 s + a 1-iteration, `PCSetUp`-bound 1.49 s solve), a large share of the `sea` phase (30–37 % of wall).

This PR addresses three things:

### 1. Cache the operator + reuse the preconditioner
- Cache the smoothing matrix (`self._smoothMat`) and a dedicated KSP (`self._ksp_smooth`: richardson + bjacobi, `marsmooth_` prefix + `pc_factor_shift_type nonzero`, mirroring `_solve_KSP`).
- Reuse the factorised PC across steps (`PC.setReusePreconditioner`); **rebuild only when the coastline (`seaID`) moves** (`_smooth_pc_ready` guards the reuse).
- Both registered in `destroy_DMPlex` (AGENTS cached-solver lifecycle rule).

### 2. Remove the timestep dependence; base the smoothing on mesh size
The old coefficient was `Kd = Cd·dt` with `Cd ∈ {1e5 (land), 5e6 (sea)}` m²/yr. Since the FV Laplacian stencil scales as `Kd/Δx²`, the *effective* smoothing strength `v ≈ Cd·dt/Δx²` silently varied with **both** the timestep **and** the mesh resolution (`~1e-3` on the coarse fixtures, `~55` on a 30 km / `dt=1e4` run). 

Replaced with a **dimensionless, mesh-size-based** coefficient `Kd = N · cell_area`, so `v ≈ N` is independent of both `dt` and resolution.

### 3. Document the values
New constants `MARINE_SMOOTH_N_LAND = 1.0` / `MARINE_SMOOTH_N_SEA = 5.0` in `constants.py` (full rationale) + AGENTS.md (Magic numbers table and the cached-solver table).

Also extracts the shared FV diffusion-matrix assembly into `_buildDiffMat` (reused by `smooth=0/1/2`; `smooth=0/1` behaviour byte-identical).

## Behaviour change (intentional)

This **changes marine sediment routing**: the smoothing strength is now consistent (`v≈5`) rather than an accident of `dt`/resolution. `N_sea=5, N_land=1` is moderate de-noising — chosen because on the coarse 3.8k-node fixture the marine flow graph (and hence the downstream conservation residual) is **non-monotonically sensitive** to the smoothing (conservation fails at `N≈1` and `N≈50`, passes in a `[2,5]` band — a coarse-mesh discrete-graph artifact). On well-resolved real meshes this sensitivity is not expected; **users may want to recalibrate `N`** against a real run (flagged in the constants comment).

## Verification

- Full suite: **67 passed, 1 skipped** (matches `dev`).
- Closed-sphere mass conservation holds serially and at **np=2** (`rel_cumED ~4e-5`).
- Caching verified **bit-faithful**: running the *old* coefficient through the new cached path keeps the dual-fine and sediment-balance conservation tests green — so the 2-test shift under the new values is the smoothing-strength change, not the caching mechanism.

## Files

`gospl/sed/hillslope.py`, `gospl/tools/constants.py`, `gospl/mesher/unstructuredmesh.py` (destroy list), `AGENTS.md`.