### PR TITLE
fix(diffusion): reset cached TS step counter each call (silent marine/soil diffusion stop)

### DIFF
--- a/gospl/eroder/soilSPL.py
+++ b/gospl/eroder/soilSPL.py
@@ -608,6 +608,12 @@ class soilSPL(object):
         # Soil thicknesses are meters; mm-level absolute tolerance is plenty.
         ts.setTolerances(atol=1e-3, rtol=1e-3)
         ts.setTime(0.0)
+        # Reset the step COUNTER (setTime only resets the clock). The cached TS
+        # is reused and getStepNumber() is not reset by setTime, so without this
+        # setMaxSteps below becomes a *cumulative* cap — after ~tsStep total
+        # substeps it is exceeded on entry and TSSolve returns immediately,
+        # leaving the soil column un-diffused (same bug as hillslope marine TS).
+        ts.setStepNumber(0)
         # Larger initial step (was self.dt / 1000.0).
         ts.setTimeStep(self.dt / 100.0)
         ts.setMaxTime(self.dt)

--- a/gospl/sed/hillslope.py
+++ b/gospl/sed/hillslope.py
@@ -675,6 +675,15 @@ class hillSLP(object):
         # artefacts seen with 1e-3/1e-3.
         ts.setTolerances(atol=5.0e-3, rtol=1.0e-4)
         ts.setTime(0.0)
+        # Reset the step COUNTER too (setTime only resets the clock). The TS is
+        # cached and reused, and getStepNumber() is NOT reset by setTime, so
+        # without this it accumulates across calls — making setMaxSteps below a
+        # *cumulative* cap that, after ~tsStep total substeps (a few hundred
+        # model steps at the default tsStep=2000), is already exceeded on entry,
+        # so TSSolve returns immediately and the marine deposit is left
+        # un-diffused (silent). It also made the verbose substep/iteration
+        # counts grow without bound (they were cumulative, not per-call).
+        ts.setStepNumber(0)
         # Initial dt close to the controller's typical equilibrium for
         # marine diffusion; minor over-large warmup is corrected by the
         # adaptive controller within a step or two.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3302,6 +3302,67 @@ def test_parallel_cached_diffusion_rebuild(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# TEST 8d - Cached marine TS: per-call step-counter reset
+# ---------------------------------------------------------------------------
+#
+# hillslope._diffuseImplicit (marine diffusion) and soilSPL.diffuseSoil reuse a
+# cached PETSc TS. `ts.setTime(0.0)` resets the clock each call but NOT the step
+# counter (`getStepNumber()`), so without an explicit `ts.setStepNumber(0)` the
+# counter accumulates across calls. `ts.setMaxSteps(self.tsStep)` then acts as a
+# CUMULATIVE cap: after ~tsStep total substeps (a few hundred model steps at the
+# default tsStep=2000) the cap is already exceeded on entry, TSSolve returns
+# immediately, and the marine deposit is left un-diffused — silently. (It also
+# made the verbose substep/iteration counts grow without bound.)
+#
+# This guard runs the marine fixture for several steps and asserts the per-call
+# TS step count stays bounded (independent per call) instead of accumulating.
+# ---------------------------------------------------------------------------
+
+
+def test_marine_ts_step_counter_resets(minimal_model):
+    """
+    Protects: hillslope._diffuseImplicit must `ts.setStepNumber(0)` each call so
+    the cached TS's `setMaxSteps(tsStep)` is a PER-CALL budget, not a cumulative
+    cap that eventually stops marine diffusion silently. Without the reset,
+    `getStepNumber()` grows monotonically across the reused TS (7, 14, 21, ...).
+    """
+    m = minimal_model
+    if getattr(m, "flatModel", False):
+        pytest.skip("needs a marine domain (global sphere) to run _diffuseImplicit")
+
+    orig = m._diffuseImplicit
+    counts = []
+
+    def wrap(*args, **kwargs):
+        out = orig(*args, **kwargs)
+        if getattr(m, "_ts_marine", None) is not None:
+            counts.append(m._ts_marine.getStepNumber())
+        return out
+
+    m._diffuseImplicit = wrap
+    try:
+        m.runProcesses()
+    finally:
+        m.destroy()
+
+    if len(counts) < 3:
+        pytest.skip(
+            f"marine diffusion ran only {len(counts)} time(s); too few to "
+            f"distinguish per-call from cumulative step counts."
+        )
+
+    # Per-call (fixed): counts stay ~flat -> max ~ min. Cumulative (bug): counts
+    # grow ~linearly with the call index -> max == N*min. The 2x bound clears the
+    # mild physical drift in substep count while failing hard on accumulation.
+    assert max(counts) <= 2 * min(counts), (
+        "Cached marine TS step counter accumulates across calls "
+        f"(getStepNumber per call = {counts}). hillslope._diffuseImplicit must "
+        "call ts.setStepNumber(0) each invocation; otherwise setMaxSteps(tsStep) "
+        "is a cumulative cap that silently stops marine diffusion on long runs."
+    )
+
+
+# ---------------------------------------------------------------------------
 # TEST 9 - Stratigraphy: deposition + compaction physics
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Bug

The cached PETSc TS in `hillslope._diffuseImplicit` (marine diffusion) and `soilSPL.diffuseSoil` (soil) is reused across timesteps. Each call does `ts.setTime(0.0)` — which resets the clock but **not** the step counter (`getStepNumber()`). So the counter **accumulates across calls**, and `ts.setMaxSteps(self.tsStep)` becomes a **cumulative** cap rather than a per-call budget: after ~`tsStep` total substeps (a few hundred model steps at the default `tsStep=2000`) the cap is already exceeded on entry, `TSSolve` returns immediately, and the deposit is left **un-diffused — silently, with no error**.

## How it surfaced

Investigating a verbose log where the marine-TS substep count grew linearly (`7 → 14 → 21 → … → 462`) over 50 steps on a **steady** marine input — which is not physical. Diagnosis:

- With a **fresh** TS each call, the per-call substep count is flat (`7,7,7,7,7,7,8,8,9,9,…`).
- The cached counts were exactly the **cumulative sum** of those (`7+7+7+7+7+7+8 = 50` ✓) — i.e. `getStepNumber()` was never reset, but the per-call *work* (and wall time, ~0.23 s) was flat all along.

**A/B with `tsStep=20`** (post-call counter):
- WITHOUT the reset: `[7, 14, 20, 20, 20, 20]` — pinned at the cap from call 3 on → **zero real work, un-diffused deposit**.
- WITH the reset: `[7, 7, 7, 7, 7, 7]`.

## Fix

`ts.setStepNumber(0)` after `setTime(0.0)` in **both** `_diffuseImplicit` and `diffuseSoil`, so `setMaxSteps(tsStep)` is a per-call budget. Pure fix — converging short runs (cumulative < `tsStep`) are unaffected; long runs no longer silently lose marine/soil diffusion. The verbose substep/iteration counts are now per-call (no longer unbounded).

## Guard

`test_marine_ts_step_counter_resets` runs the marine fixture and asserts the per-call TS step count stays bounded (not accumulating). Verified: **passes with the fix, fails without** (counts `[3, 6, 9, …, 60]`).

## Verification

Full suite: **69 passed, 1 skipped**.

## Files

`gospl/sed/hillslope.py`, `gospl/eroder/soilSPL.py`, `tests/test_regression.py`.