### PR TITLE
perf(sea): opt-in lagged-diffusivity (Picard) marine solver + RTD API-docs fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tests/fixtures/incising/
 tests/fixtures/minimal_strat/
 tests/fixtures/minimal_dual/
 tests/fixtures/minimal_dual_coarse/
+tests/fixtures/minimal_picard/
 tests/fixtures/minimal_ice/
 tests/fixtures/ice_soil_out/
 tests/fixtures/minimal_ice_till/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Rule: use `MPI.COMM_WORLD` for raw collectives (Allreduce/bcast/Allgatherv); use
 ## KSP / SNES / TS lifecycle contract
 PETSc solvers in goSPL follow two intentional patterns. **Use the right one for new code.**
 
-### CACHED — hot-path solvers (10 sites)
+### CACHED — hot-path solvers (11 sites)
 Solvers that run **every timestep** are created lazily on first use, stored as `self._X`, and reused across the entire simulation. Avoids the ~5-10 ms create+destroy churn per call, which compounds over thousands of timesteps. Each site's inline docstring confirms the rationale.
 
 | File | Method | Cached attribute | Solver |
@@ -63,6 +63,7 @@ Solvers that run **every timestep** are created lazily on first use, stored as `
 | `sed/hillslope.py` | `_diffuseImplicit` | `self._ts_marine` | TS (rosw marine + lake diffusion) |
 | `sed/hillslope.py` | `_solveSmooth` | `self._ksp_smooth` (+ cached operator `self._smoothMat`) | KSP (richardson+bjacobi, `marsmooth_` prefix, factor-shift) for the marine flow-direction smoother (`_hillSlope(smooth=2)`). Operator is mesh-size-based + timestep-independent so it is built once and the PC **reused**; rebuilt only when the coastline (`seaID`) moves (`_smooth_pc_ready` guards the reuse). |
 | `sed/hillslope.py` | `_hillSlope(smooth=0)` | `self._ksp_hill_lin` (+ cached operator `self._hillMat`) | KSP (`hilllin_` prefix; same config via shared `_makeDiffusionKSP`) for the **linear** soil-creep solve. Operator `(I−Cd·dt·L)` is invariant for constant `Cda`/`Cdm`, so built once + PC **reused**, rebuilt only on coastline move (`_hill_pc_ready`). **Only when NOT dual-lithology** (`stratLith` makes `Cd` step-varying → per-step build on `_ksp_main`). Bit-faithful. |
+| `sed/hillslope.py` | `_diffuseImplicitPicard` | `self._ksp_picard` | KSP (`marpicard_` prefix; `_makeDiffusionKSP`) for the **opt-in** lagged-diffusivity marine/lake solver (`diffusion: marineSolver: picard`; default `ts` = the adaptive non-linear `_ts_marine`). Per Picard iteration it rebuilds `M = I + dt_sub·L` from `jacobiancoeff(h,Cd,Kp=0)` (the linear `∇·(Cd∇)` operator, **consistent with the TS residual `fctcoeff`** incl. the no-flux-across-zero-Cd-face marine-mask gating) via the single-pass `_assembleDiffMatCSR`, and solves it (no SNES). The operator changes each iteration so PCSetUp is not reused — but each solve is linear + smooth (no kink rejections). Approximation: matches the TS to ~1e-5 on minimal, ~1.5% deposit diff on a 658k earth run at ~5-8× the marine-diffusion speed; `picardSub`/`picardIts` are the accuracy/speed knobs. |
 
 **CRITICAL — collective rebuild decision.** Both coastline-gated caches above (`_smoothMat`/`_hillMat`) rebuild the operator (and redo `PCSetUp`) only when `seaID` moves. `seaID` is **rank-local**, but `_buildDiffMat` assembly and `PCSetUp` are **collective** — so the "did the coastline move?" test MUST be reduced across ranks (`rebuild = MPI.COMM_WORLD.allreduce(local_changed, op=MPI.LOR)`) before it gates those calls. Without the reduce, one rank rebuilds while another reuses, the two take different collective paths, and the run **deadlocks at np>1** (it ran fine until the per-partition coastlines drifted apart, then hung). A rank forced to rebuild with an unchanged mask reproduces its own cached matrix, so the reduce stays bit-faithful. Any future cached operator gated on a rank-local condition needs the same reduce.
 
@@ -208,7 +209,7 @@ NOT optional parsers. Each sets attributes required by other modules. Never dele
 
 - `_extraDomain` (inputparser.py:189) → `seaDepo`, `overlap`, `dataFile`, `nodep`, `strataFile`; calls `_extraDomain2`.
 - `_extraDomain2` (:229) → `advscheme`, `radius`, `gravity`.
-- `_extraHillslope` (:475) → `nlK`, `clinSlp`, `tsStep`, `Gmar`, `offshore`, `nl_pit_volume/depth/K/inlet_bias`.
+- `_extraHillslope` (:475) → `nlK`, `clinSlp`, `tsStep`, `Gmar`, `offshore`, `nl_pit_volume/depth/K/inlet_bias`, `marineSolver`(`ts`|`picard`)/`picardSub`/`picardIts` (opt-in lagged-diffusivity marine/lake solver).
 - `_extraStrata` (called from `_readCompaction`) → `stratLith` (dual-lithology master opt-in), `phi0c/z0c` (coarse porosity curve, defaults to compaction `phi0s/z0s`), `phi0f/z0f` (fine), `fine_k_factor` (fine erodibility multiplier), `bedrock_coarse_frac`, `fine_efficiency`, `pit_inlet_bias_coarse/fine`, `fine_diff_factor` (fine diffusivity multiplier). All inert while `stratLith` is False; forced False if `stratNb == 0`. See `docs/DESIGN_DUAL_LITHOLOGY.md`.
 - `_extraFlex` (:1430) → `nu`, `flex_res_deg`, `flex_bcN/S/E/W`.
 - `_extraOrography` (:1517) → `oro_cw`, `oro_conv_time`, `oro_fall_time`, `oro_precip_*`, `rainfall_frequency`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,12 @@ Each of these is marked with a permanent `# TODO-REFACTOR: value matches X but d
 - The issue triage automation is designed to be transparent and idempotent: before posting a new automated response, the bot checks for an identical existing triage comment and skips duplicates when a workflow retry would otherwise repeat the same reply.
 - Concurrency: `tests-pr.yml` cancels in-flight runs on the same ref (`cancel-in-progress: true`); `tests-slow.yml` does not (`cancel-in-progress: false`) — slow runs are expensive enough that killing them mid-flight is more wasteful than letting them finish.
 
+## Docs / Read the Docs (autodoc)
+The API reference (`docs/api_ref/*.rst`) is Sphinx **autodoc** — it imports each module to extract docstrings, so the modules MUST import under the docs build. Two invariants keep the API pages from rendering empty (both regressed once and produced blank pages for *most* classes):
+- **`gospl` must be importable.** It is NOT pip-installed on Read the Docs, so `docs/conf.py` puts BOTH the repo root (`..`, so `from gospl.tools.constants import …` and other `from gospl.X import` resolve) AND `../gospl/` (so the legacy top-level `.. autoclass:: sed.hillslope.hillSLP` paths resolve) on `sys.path`. Don't remove either.
+- **Mock only the genuinely-absent compiled/MPI deps via `autodoc_mock_imports`** (`h5py`, `mpi4py`, `petsc4py`, `vtk`, `gflex`, `pyshtools`, `gospl._fortran`). Do NOT mock packages `docs/requirements.txt` installs (`numpy`, `scipy`, `pandas`, `numpy-indexed`, `ruamel.yaml`) — the old manual `sys.modules[m] = Mock()` shadowed the real `scipy` and broke `from scipy.special import …` (and didn't cover submodules), blanking the pages. `autodoc_mock_imports` mocks submodules automatically; the `READTHEDOCS` env-guard around `from gospl._fortran import …` is the belt-and-braces for the compiled extension.
+- When you add a public/private method that should appear in the API, add it to BOTH the `.. autosummary::` and `.. automethod::` lists in the relevant `docs/api_ref/*_ref.rst` (they are hand-maintained, not auto-generated).
+
 ## Analytical benchmark suite
 Tests in `benchmarks/` validate goSPL physics against exact analytical solutions. They require `scipy` and `matplotlib` and are silently skipped via `pytest.importorskip` in environments without these packages. `matplotlib` is in `environment.yml` for CI; it is NOT a goSPL runtime dependency (intentional — `pyproject.toml` does not list it).
 

--- a/docs/api_ref/flow_ref.rst
+++ b/docs/api_ref/flow_ref.rst
@@ -17,31 +17,37 @@ Class FAMesh
 
    .. autosummary::
 
-      ~FAMesh.flowAccumulation
       ~FAMesh.matrixFlow
+      ~FAMesh.flowAccumulation
 
    .. rubric:: Private Methods
 
    .. autosummary::
 
-      ~FAMesh._buildFlowDirection
-      ~FAMesh._distributeDownstream
       ~FAMesh._matrix_build
       ~FAMesh._matrix_build_diag
+      ~FAMesh._make_reasons
+      ~FAMesh._solve_KSP2
       ~FAMesh._solve_KSP
+      ~FAMesh._buildFlowDirection
+      ~FAMesh._potentialLakeEvap
+      ~FAMesh._distributeDownstream
 
 Public functions
 ---------------------
 
-.. automethod:: flow.flowplex.FAMesh.flowAccumulation
 .. automethod:: flow.flowplex.FAMesh.matrixFlow
+.. automethod:: flow.flowplex.FAMesh.flowAccumulation
 
 
 Private functions
 ---------------------
 
-.. automethod:: flow.flowplex.FAMesh._buildFlowDirection
-.. automethod:: flow.flowplex.FAMesh._distributeDownstream
 .. automethod:: flow.flowplex.FAMesh._matrix_build
 .. automethod:: flow.flowplex.FAMesh._matrix_build_diag
+.. automethod:: flow.flowplex.FAMesh._make_reasons
+.. automethod:: flow.flowplex.FAMesh._solve_KSP2
 .. automethod:: flow.flowplex.FAMesh._solve_KSP
+.. automethod:: flow.flowplex.FAMesh._buildFlowDirection
+.. automethod:: flow.flowplex.FAMesh._potentialLakeEvap
+.. automethod:: flow.flowplex.FAMesh._distributeDownstream

--- a/docs/api_ref/grid_ref.rst
+++ b/docs/api_ref/grid_ref.rst
@@ -24,10 +24,15 @@ Class GridProcess
 
    .. autosummary::
 
-      ~GridProcess._buildRegGrid
       ~GridProcess._regInterp
+      ~GridProcess._buildRegGrid
       ~GridProcess._updateTe
-      
+      ~GridProcess._cptFlex2D
+      ~GridProcess._buildDHGrid
+      ~GridProcess._unstr2dh
+      ~GridProcess._dh2unstr
+      ~GridProcess._cmptFlexGlobal
+
 
 Public functions
 ---------------------
@@ -39,6 +44,11 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: tools.addprocess.GridProcess._buildRegGrid
 .. automethod:: tools.addprocess.GridProcess._regInterp
+.. automethod:: tools.addprocess.GridProcess._buildRegGrid
 .. automethod:: tools.addprocess.GridProcess._updateTe
+.. automethod:: tools.addprocess.GridProcess._cptFlex2D
+.. automethod:: tools.addprocess.GridProcess._buildDHGrid
+.. automethod:: tools.addprocess.GridProcess._unstr2dh
+.. automethod:: tools.addprocess.GridProcess._dh2unstr
+.. automethod:: tools.addprocess.GridProcess._cmptFlexGlobal

--- a/docs/api_ref/hill_ref.rst
+++ b/docs/api_ref/hill_ref.rst
@@ -23,12 +23,21 @@ Class hillSLP
 
    .. autosummary::
 
-      ~hillSLP._diffuseOcean
+      ~hillSLP._hillSlope
+      ~hillSLP._buildDiffMat
+      ~hillSLP._assembleDiffMat
+      ~hillSLP._assembleDiffMatCSR
+      ~hillSLP._makeDiffusionKSP
+      ~hillSLP._solveSmooth
+      ~hillSLP._diff_nl_monitor
+      ~hillSLP._form_residual_nl_hillslope
+      ~hillSLP._hillSlopeNL
       ~hillSLP._evalFunctionMardDiff
       ~hillSLP._evalJacobianMardDiff
-      ~hillSLP._form_residual_nl_hillslope
-      ~hillSLP._hillSlope
-      ~hillSLP._hillSlopeNL
+      ~hillSLP._evalSolutionMardDiff
+      ~hillSLP._diffuseOcean
+      ~hillSLP._diffuseImplicit
+      ~hillSLP._diffuseImplicitPicard
 
 Public functions
 ---------------------
@@ -39,9 +48,18 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: sed.hillslope.hillSLP._diffuseOcean
+.. automethod:: sed.hillslope.hillSLP._hillSlope
+.. automethod:: sed.hillslope.hillSLP._buildDiffMat
+.. automethod:: sed.hillslope.hillSLP._assembleDiffMat
+.. automethod:: sed.hillslope.hillSLP._assembleDiffMatCSR
+.. automethod:: sed.hillslope.hillSLP._makeDiffusionKSP
+.. automethod:: sed.hillslope.hillSLP._solveSmooth
+.. automethod:: sed.hillslope.hillSLP._diff_nl_monitor
+.. automethod:: sed.hillslope.hillSLP._form_residual_nl_hillslope
+.. automethod:: sed.hillslope.hillSLP._hillSlopeNL
 .. automethod:: sed.hillslope.hillSLP._evalFunctionMardDiff
 .. automethod:: sed.hillslope.hillSLP._evalJacobianMardDiff
-.. automethod:: sed.hillslope.hillSLP._form_residual_nl_hillslope
-.. automethod:: sed.hillslope.hillSLP._hillSlope
-.. automethod:: sed.hillslope.hillSLP._hillSlopeNL
+.. automethod:: sed.hillslope.hillSLP._evalSolutionMardDiff
+.. automethod:: sed.hillslope.hillSLP._diffuseOcean
+.. automethod:: sed.hillslope.hillSLP._diffuseImplicit
+.. automethod:: sed.hillslope.hillSLP._diffuseImplicitPicard

--- a/docs/api_ref/in_ref.rst
+++ b/docs/api_ref/in_ref.rst
@@ -17,52 +17,82 @@ Class ReadYaml
 
    .. autosummary::
 
-      ~ReadYaml._addTime
-      ~ReadYaml._defineErofactor
-      ~ReadYaml._defineRain
-      ~ReadYaml._defineTectonics
-      ~ReadYaml._extraDomain
-      ~ReadYaml._extraHillslope
-      ~ReadYaml._extraOrography
-      ~ReadYaml._readCompaction
+      ~ReadYaml._get_param
+      ~ReadYaml._restartUpdate
       ~ReadYaml._readDomain
-      ~ReadYaml._readErofactor
-      ~ReadYaml._readFlex
-      ~ReadYaml._readHillslope
-      ~ReadYaml._readIce
-      ~ReadYaml._readOrography
-      ~ReadYaml._readOut
-      ~ReadYaml._readRain
-      ~ReadYaml._readSoilInfo
-      ~ReadYaml._readSPL
-      ~ReadYaml._readSealevel
-      ~ReadYaml._readTectonics
+      ~ReadYaml._extraDomain
+      ~ReadYaml._extraDomain2
       ~ReadYaml._readTime
+      ~ReadYaml._addTime
+      ~ReadYaml._readSPL
+      ~ReadYaml._readHillslope
+      ~ReadYaml._extraHillslope
+      ~ReadYaml._readSoilInfo
+      ~ReadYaml._readSealevel
+      ~ReadYaml._isKeyinFile
       ~ReadYaml._storeTectonics
+      ~ReadYaml._defineTectonics
+      ~ReadYaml._readTectonics
+      ~ReadYaml._defineErofactor
+      ~ReadYaml._readErofactor
+      ~ReadYaml._getTe
+      ~ReadYaml._readTeMap
+      ~ReadYaml._defineRain
+      ~ReadYaml._defineEvap
+      ~ReadYaml._readRain
+      ~ReadYaml._readCompaction
+      ~ReadYaml._extraStrata
+      ~ReadYaml._extraProvenance
+      ~ReadYaml._readFlex
+      ~ReadYaml._extraFlex
+      ~ReadYaml._readOrography
+      ~ReadYaml._extraOrography
+      ~ReadYaml._readIce
+      ~ReadYaml._iceGeomField
+      ~ReadYaml._buildIceSeries
+      ~ReadYaml._extraIce
+      ~ReadYaml._checkMap
+      ~ReadYaml._loadIceMap
+      ~ReadYaml._readOut
 
 
 Private functions
 ---------------------
 
-.. automethod:: tools.inputparser.ReadYaml._addTime
-.. automethod:: tools.inputparser.ReadYaml._defineErofactor
-.. automethod:: tools.inputparser.ReadYaml._defineRain
-.. automethod:: tools.inputparser.ReadYaml._defineTectonics
-.. automethod:: tools.inputparser.ReadYaml._extraDomain
-.. automethod:: tools.inputparser.ReadYaml._extraHillslope
-.. automethod:: tools.inputparser.ReadYaml._extraOrography
-.. automethod:: tools.inputparser.ReadYaml._readCompaction
+.. automethod:: tools.inputparser.ReadYaml._get_param
+.. automethod:: tools.inputparser.ReadYaml._restartUpdate
 .. automethod:: tools.inputparser.ReadYaml._readDomain
-.. automethod:: tools.inputparser.ReadYaml._readErofactor
-.. automethod:: tools.inputparser.ReadYaml._readFlex
-.. automethod:: tools.inputparser.ReadYaml._readHillslope
-.. automethod:: tools.inputparser.ReadYaml._readIce
-.. automethod:: tools.inputparser.ReadYaml._readOrography
-.. automethod:: tools.inputparser.ReadYaml._readOut
-.. automethod:: tools.inputparser.ReadYaml._readRain
-.. automethod:: tools.inputparser.ReadYaml._readSoilInfo
-.. automethod:: tools.inputparser.ReadYaml._readSPL
-.. automethod:: tools.inputparser.ReadYaml._readSealevel
-.. automethod:: tools.inputparser.ReadYaml._readTectonics
+.. automethod:: tools.inputparser.ReadYaml._extraDomain
+.. automethod:: tools.inputparser.ReadYaml._extraDomain2
 .. automethod:: tools.inputparser.ReadYaml._readTime
+.. automethod:: tools.inputparser.ReadYaml._addTime
+.. automethod:: tools.inputparser.ReadYaml._readSPL
+.. automethod:: tools.inputparser.ReadYaml._readHillslope
+.. automethod:: tools.inputparser.ReadYaml._extraHillslope
+.. automethod:: tools.inputparser.ReadYaml._readSoilInfo
+.. automethod:: tools.inputparser.ReadYaml._readSealevel
+.. automethod:: tools.inputparser.ReadYaml._isKeyinFile
 .. automethod:: tools.inputparser.ReadYaml._storeTectonics
+.. automethod:: tools.inputparser.ReadYaml._defineTectonics
+.. automethod:: tools.inputparser.ReadYaml._readTectonics
+.. automethod:: tools.inputparser.ReadYaml._defineErofactor
+.. automethod:: tools.inputparser.ReadYaml._readErofactor
+.. automethod:: tools.inputparser.ReadYaml._getTe
+.. automethod:: tools.inputparser.ReadYaml._readTeMap
+.. automethod:: tools.inputparser.ReadYaml._defineRain
+.. automethod:: tools.inputparser.ReadYaml._defineEvap
+.. automethod:: tools.inputparser.ReadYaml._readRain
+.. automethod:: tools.inputparser.ReadYaml._readCompaction
+.. automethod:: tools.inputparser.ReadYaml._extraStrata
+.. automethod:: tools.inputparser.ReadYaml._extraProvenance
+.. automethod:: tools.inputparser.ReadYaml._readFlex
+.. automethod:: tools.inputparser.ReadYaml._extraFlex
+.. automethod:: tools.inputparser.ReadYaml._readOrography
+.. automethod:: tools.inputparser.ReadYaml._extraOrography
+.. automethod:: tools.inputparser.ReadYaml._readIce
+.. automethod:: tools.inputparser.ReadYaml._iceGeomField
+.. automethod:: tools.inputparser.ReadYaml._buildIceSeries
+.. automethod:: tools.inputparser.ReadYaml._extraIce
+.. automethod:: tools.inputparser.ReadYaml._checkMap
+.. automethod:: tools.inputparser.ReadYaml._loadIceMap
+.. automethod:: tools.inputparser.ReadYaml._readOut

--- a/docs/api_ref/mesh_ref.rst
+++ b/docs/api_ref/mesh_ref.rst
@@ -24,14 +24,18 @@ Class UnstMesh
 
    .. autosummary::
 
-      ~UnstMesh._buildMesh
-      ~UnstMesh._generateVTKmesh
-      ~UnstMesh._get_boundary
       ~UnstMesh._meshfrom_cell_list
       ~UnstMesh._meshStructure
-      ~UnstMesh._readErosionDeposition
+      ~UnstMesh._generateVTKmesh
+      ~UnstMesh._buildMesh
+      ~UnstMesh._gatherGlobalOnRoot
       ~UnstMesh._set_DMPlex_boundary_points
+      ~UnstMesh._get_boundary
+      ~UnstMesh._readErosionDeposition
       ~UnstMesh._updateRain
+      ~UnstMesh._updateIce
+      ~UnstMesh._resolveIceField
+      ~UnstMesh._updateEvap
       ~UnstMesh._updateEroFactor
 
 Public functions
@@ -45,12 +49,16 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: mesher.unstructuredmesh.UnstMesh._buildMesh
-.. automethod:: mesher.unstructuredmesh.UnstMesh._generateVTKmesh
-.. automethod:: mesher.unstructuredmesh.UnstMesh._get_boundary
 .. automethod:: mesher.unstructuredmesh.UnstMesh._meshfrom_cell_list
 .. automethod:: mesher.unstructuredmesh.UnstMesh._meshStructure
-.. automethod:: mesher.unstructuredmesh.UnstMesh._readErosionDeposition
+.. automethod:: mesher.unstructuredmesh.UnstMesh._generateVTKmesh
+.. automethod:: mesher.unstructuredmesh.UnstMesh._buildMesh
+.. automethod:: mesher.unstructuredmesh.UnstMesh._gatherGlobalOnRoot
 .. automethod:: mesher.unstructuredmesh.UnstMesh._set_DMPlex_boundary_points
+.. automethod:: mesher.unstructuredmesh.UnstMesh._get_boundary
+.. automethod:: mesher.unstructuredmesh.UnstMesh._readErosionDeposition
 .. automethod:: mesher.unstructuredmesh.UnstMesh._updateRain
+.. automethod:: mesher.unstructuredmesh.UnstMesh._updateIce
+.. automethod:: mesher.unstructuredmesh.UnstMesh._resolveIceField
+.. automethod:: mesher.unstructuredmesh.UnstMesh._updateEvap
 .. automethod:: mesher.unstructuredmesh.UnstMesh._updateEroFactor

--- a/docs/api_ref/model_ref.rst
+++ b/docs/api_ref/model_ref.rst
@@ -1,8 +1,9 @@
 .. _model_ref:
 
-==============
+
+===========
 Class Model
-==============
+===========
 
 .. autoclass:: model.Model
 
@@ -18,6 +19,7 @@ Class Model
 
       ~Model.runProcesses
       ~Model.destroy
+
 
 Public functions
 ---------------------

--- a/docs/api_ref/nlspl_ref.rst
+++ b/docs/api_ref/nlspl_ref.rst
@@ -25,10 +25,12 @@ Class nlSPL
 
       ~nlSPL._form_residual
       ~nlSPL._form_residual_ed
+      ~nlSPL._monitor
       ~nlSPL._form_jacobian
-      ~nlSPL._getEroDepRateNL
-      ~nlSPL._solveNL
+      ~nlSPL._build_ed_snes
       ~nlSPL._solveNL_ed
+      ~nlSPL._solveNL
+      ~nlSPL._getEroDepRateNL
 
 Public functions
 ---------------------
@@ -41,7 +43,9 @@ Private functions
 
 .. automethod:: eroder.nlSPL.nlSPL._form_residual
 .. automethod:: eroder.nlSPL.nlSPL._form_residual_ed
+.. automethod:: eroder.nlSPL.nlSPL._monitor
 .. automethod:: eroder.nlSPL.nlSPL._form_jacobian
-.. automethod:: eroder.nlSPL.nlSPL._getEroDepRateNL
-.. automethod:: eroder.nlSPL.nlSPL._solveNL
+.. automethod:: eroder.nlSPL.nlSPL._build_ed_snes
 .. automethod:: eroder.nlSPL.nlSPL._solveNL_ed
+.. automethod:: eroder.nlSPL.nlSPL._solveNL
+.. automethod:: eroder.nlSPL.nlSPL._getEroDepRateNL

--- a/docs/api_ref/out_ref.rst
+++ b/docs/api_ref/out_ref.rst
@@ -17,17 +17,16 @@ Class WriteMesh
 
    .. autosummary::
 
-      ~WriteMesh.readData
       ~WriteMesh.visModel
-
+      ~WriteMesh.readData
 
    .. rubric:: Private Methods
 
    .. autosummary::
 
       ~WriteMesh._createOutputDir
-      ~WriteMesh._outputMesh
       ~WriteMesh._outputStrat
+      ~WriteMesh._outputMesh
       ~WriteMesh._save_DMPlex_XMF
       ~WriteMesh._save_XDMF
 
@@ -35,15 +34,15 @@ Class WriteMesh
 Public functions
 ---------------------
 
-.. automethod:: tools.outmesh.WriteMesh.readData
 .. automethod:: tools.outmesh.WriteMesh.visModel
+.. automethod:: tools.outmesh.WriteMesh.readData
 
 
 Private functions
 ---------------------
 
 .. automethod:: tools.outmesh.WriteMesh._createOutputDir
-.. automethod:: tools.outmesh.WriteMesh._outputMesh
 .. automethod:: tools.outmesh.WriteMesh._outputStrat
+.. automethod:: tools.outmesh.WriteMesh._outputMesh
 .. automethod:: tools.outmesh.WriteMesh._save_DMPlex_XMF
 .. automethod:: tools.outmesh.WriteMesh._save_XDMF

--- a/docs/api_ref/pit_ref.rst
+++ b/docs/api_ref/pit_ref.rst
@@ -25,14 +25,14 @@ Class PITFill
    .. autosummary::
 
       ~PITFill._buildPitDataframe
-      ~PITFill._dirFlats
-      ~PITFill._fillFromEdges
-      ~PITFill._getPitParams
+      ~PITFill._sortingPits
       ~PITFill._offsetGlobal
+      ~PITFill._fillFromEdges
+      ~PITFill._transferIDs
+      ~PITFill._dirFlats
+      ~PITFill._getPitParams
       ~PITFill._performFilling
       ~PITFill._pitInformation
-      ~PITFill._sortingPits
-      ~PITFill._transferIDs
 
 Public functions
 ---------------------
@@ -45,11 +45,11 @@ Private functions
 ---------------------
 
 .. automethod:: flow.pitfilling.PITFill._buildPitDataframe
-.. automethod:: flow.pitfilling.PITFill._dirFlats
-.. automethod:: flow.pitfilling.PITFill._fillFromEdges
-.. automethod:: flow.pitfilling.PITFill._getPitParams
+.. automethod:: flow.pitfilling.PITFill._sortingPits
 .. automethod:: flow.pitfilling.PITFill._offsetGlobal
+.. automethod:: flow.pitfilling.PITFill._fillFromEdges
+.. automethod:: flow.pitfilling.PITFill._transferIDs
+.. automethod:: flow.pitfilling.PITFill._dirFlats
+.. automethod:: flow.pitfilling.PITFill._getPitParams
 .. automethod:: flow.pitfilling.PITFill._performFilling
 .. automethod:: flow.pitfilling.PITFill._pitInformation
-.. automethod:: flow.pitfilling.PITFill._sortingPits
-.. automethod:: flow.pitfilling.PITFill._transferIDs

--- a/docs/api_ref/plate_ref.rst
+++ b/docs/api_ref/plate_ref.rst
@@ -24,12 +24,14 @@ Class Tectonics
 
    .. autosummary::
 
-      ~Tectonics._advectPlates
-      ~Tectonics._advectStrati
-      ~Tectonics._findPts2Reduce
-      ~Tectonics._readAdvectionData
-      ~Tectonics._updateStratInfo
+      ~Tectonics._buildAdvecMat
+      ~Tectonics._advectorIIOE2
       ~Tectonics._varAdvector
+      ~Tectonics._readAdvectionData
+      ~Tectonics._advectPlates
+      ~Tectonics._findPts2Reduce
+      ~Tectonics._advectStrati
+      ~Tectonics._updateStratInfo
 
 Public functions
 ---------------------
@@ -41,9 +43,11 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: mesher.tectonics.Tectonics._advectPlates
-.. automethod:: mesher.tectonics.Tectonics._advectStrati
-.. automethod:: mesher.tectonics.Tectonics._findPts2Reduce
-.. automethod:: mesher.tectonics.Tectonics._readAdvectionData
-.. automethod:: mesher.tectonics.Tectonics._updateStratInfo
+.. automethod:: mesher.tectonics.Tectonics._buildAdvecMat
+.. automethod:: mesher.tectonics.Tectonics._advectorIIOE2
 .. automethod:: mesher.tectonics.Tectonics._varAdvector
+.. automethod:: mesher.tectonics.Tectonics._readAdvectionData
+.. automethod:: mesher.tectonics.Tectonics._advectPlates
+.. automethod:: mesher.tectonics.Tectonics._findPts2Reduce
+.. automethod:: mesher.tectonics.Tectonics._advectStrati
+.. automethod:: mesher.tectonics.Tectonics._updateStratInfo

--- a/docs/api_ref/sea_ref.rst
+++ b/docs/api_ref/sea_ref.rst
@@ -23,11 +23,13 @@ Class SEAMesh
 
    .. autosummary::
 
-      ~SEAMesh._depMarineSystem
-      ~SEAMesh._distanceCoasts
-      ~SEAMesh._distOcean
       ~SEAMesh._globalCoastsTree
+      ~SEAMesh._distanceCoasts
       ~SEAMesh._matOcean
+      ~SEAMesh._depMarineSystem
+      ~SEAMesh._distOcean
+      ~SEAMesh._marineFineFraction
+      ~SEAMesh._marineProvFraction
 
 Public functions
 ---------------------
@@ -38,8 +40,10 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: sed.seaplex.SEAMesh._depMarineSystem
-.. automethod:: sed.seaplex.SEAMesh._distanceCoasts
-.. automethod:: sed.seaplex.SEAMesh._distOcean
 .. automethod:: sed.seaplex.SEAMesh._globalCoastsTree
+.. automethod:: sed.seaplex.SEAMesh._distanceCoasts
 .. automethod:: sed.seaplex.SEAMesh._matOcean
+.. automethod:: sed.seaplex.SEAMesh._depMarineSystem
+.. automethod:: sed.seaplex.SEAMesh._distOcean
+.. automethod:: sed.seaplex.SEAMesh._marineFineFraction
+.. automethod:: sed.seaplex.SEAMesh._marineProvFraction

--- a/docs/api_ref/sed_ref.rst
+++ b/docs/api_ref/sed_ref.rst
@@ -23,9 +23,16 @@ Class SEDMesh
 
    .. autosummary::
 
-      ~SEDMesh._distributeSediment
       ~SEDMesh._getSedFlux
       ~SEDMesh._moveDownstream
+      ~SEDMesh._distributeSediment
+      ~SEDMesh._bottomUpDelta
+      ~SEDMesh._spillCoords
+      ~SEDMesh._addPitMicroTilt
+      ~SEDMesh._identifyPitInlets
+      ~SEDMesh._diffuseLargePit
+      ~SEDMesh._pitFineFraction
+      ~SEDMesh._pitProvFraction
       ~SEDMesh._updateSinks
 
 Public functions
@@ -37,7 +44,14 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: sed.sedplex.SEDMesh._distributeSediment
 .. automethod:: sed.sedplex.SEDMesh._getSedFlux
 .. automethod:: sed.sedplex.SEDMesh._moveDownstream
+.. automethod:: sed.sedplex.SEDMesh._distributeSediment
+.. automethod:: sed.sedplex.SEDMesh._bottomUpDelta
+.. automethod:: sed.sedplex.SEDMesh._spillCoords
+.. automethod:: sed.sedplex.SEDMesh._addPitMicroTilt
+.. automethod:: sed.sedplex.SEDMesh._identifyPitInlets
+.. automethod:: sed.sedplex.SEDMesh._diffuseLargePit
+.. automethod:: sed.sedplex.SEDMesh._pitFineFraction
+.. automethod:: sed.sedplex.SEDMesh._pitProvFraction
 .. automethod:: sed.sedplex.SEDMesh._updateSinks

--- a/docs/api_ref/soilspl_ref.rst
+++ b/docs/api_ref/soilspl_ref.rst
@@ -17,35 +17,39 @@ Class soilSPL
 
    .. autosummary::
 
-      ~soilSPL.diffuseSoil
-      ~soilSPL.erodepSPLsoil
       ~soilSPL.updateSoilThickness
+      ~soilSPL.erodepSPLsoil
+      ~soilSPL.diffuseSoil
 
    .. rubric:: Private Methods
 
    .. autosummary::
 
+      ~soilSPL._form_residual_soil
+      ~soilSPL._monitorsoil
+      ~soilSPL._build_soil_snes
+      ~soilSPL._solveSoil
+      ~soilSPL._getEroDepRateSoil
       ~soilSPL._evalFunctionSoil
       ~soilSPL._evalJacobianSoil
       ~soilSPL._evalSolutionSoil
-      ~soilSPL._form_residual_soil
-      ~soilSPL._getEroDepRateSoil
-      ~soilSPL._solveSoil
 
 Public functions
 ---------------------
 
-.. automethod:: eroder.soilSPL.soilSPL.diffuseSoil
-.. automethod:: eroder.soilSPL.soilSPL.erodepSPLsoil
 .. automethod:: eroder.soilSPL.soilSPL.updateSoilThickness
+.. automethod:: eroder.soilSPL.soilSPL.erodepSPLsoil
+.. automethod:: eroder.soilSPL.soilSPL.diffuseSoil
 
 
 Private functions
 ---------------------
 
+.. automethod:: eroder.soilSPL.soilSPL._form_residual_soil
+.. automethod:: eroder.soilSPL.soilSPL._monitorsoil
+.. automethod:: eroder.soilSPL.soilSPL._build_soil_snes
+.. automethod:: eroder.soilSPL.soilSPL._solveSoil
+.. automethod:: eroder.soilSPL.soilSPL._getEroDepRateSoil
 .. automethod:: eroder.soilSPL.soilSPL._evalFunctionSoil
 .. automethod:: eroder.soilSPL.soilSPL._evalJacobianSoil
 .. automethod:: eroder.soilSPL.soilSPL._evalSolutionSoil
-.. automethod:: eroder.soilSPL.soilSPL._form_residual_soil
-.. automethod:: eroder.soilSPL.soilSPL._getEroDepRateSoil
-.. automethod:: eroder.soilSPL.soilSPL._solveSoil

--- a/docs/api_ref/spl_ref.rst
+++ b/docs/api_ref/spl_ref.rst
@@ -23,9 +23,10 @@ Class SPL
 
    .. autosummary::
 
-      ~SPL._coupledEDSystem
       ~SPL._eroMats
+      ~SPL._coupledEDSystem
       ~SPL._getEroDepRate
+      ~SPL._glacialAbrasion
 
 Public functions
 ---------------------
@@ -36,6 +37,7 @@ Public functions
 Private functions
 ---------------------
 
-.. automethod:: eroder.SPL.SPL._coupledEDSystem
 .. automethod:: eroder.SPL.SPL._eroMats
+.. automethod:: eroder.SPL.SPL._coupledEDSystem
 .. automethod:: eroder.SPL.SPL._getEroDepRate
+.. automethod:: eroder.SPL.SPL._glacialAbrasion

--- a/docs/api_ref/stra_ref.rst
+++ b/docs/api_ref/stra_ref.rst
@@ -16,35 +16,45 @@ Class StraMesh
 
    .. autosummary::
 
+      ~STRAMesh.readStratLayers
       ~STRAMesh.deposeStrat
       ~STRAMesh.erodeStrat
       ~STRAMesh.elevStrat
       ~STRAMesh.getCompaction
-      ~STRAMesh.readStratLayers
       ~STRAMesh.stratalRecord
 
    .. rubric:: Private Methods
 
    .. autosummary::
 
-      ~STRAMesh._depthPorosity
+      ~STRAMesh._initProvenance
       ~STRAMesh._fillZeroPorosity
       ~STRAMesh._surfaceK
+      ~STRAMesh._surfaceComposition
+      ~STRAMesh._surfaceLithoK
+      ~STRAMesh._surfaceLithoD
+      ~STRAMesh._depthPorosity
+      ~STRAMesh._depthPorosityDual
 
 Public functions
 ---------------------
 
+.. automethod:: sed.stratplex.STRAMesh.readStratLayers
 .. automethod:: sed.stratplex.STRAMesh.deposeStrat
 .. automethod:: sed.stratplex.STRAMesh.erodeStrat
 .. automethod:: sed.stratplex.STRAMesh.elevStrat
 .. automethod:: sed.stratplex.STRAMesh.getCompaction
-.. automethod:: sed.stratplex.STRAMesh.readStratLayers
 .. automethod:: sed.stratplex.STRAMesh.stratalRecord
 
 
 Private functions
 ---------------------
 
-.. automethod:: sed.stratplex.STRAMesh._depthPorosity
+.. automethod:: sed.stratplex.STRAMesh._initProvenance
 .. automethod:: sed.stratplex.STRAMesh._fillZeroPorosity
 .. automethod:: sed.stratplex.STRAMesh._surfaceK
+.. automethod:: sed.stratplex.STRAMesh._surfaceComposition
+.. automethod:: sed.stratplex.STRAMesh._surfaceLithoK
+.. automethod:: sed.stratplex.STRAMesh._surfaceLithoD
+.. automethod:: sed.stratplex.STRAMesh._depthPorosity
+.. automethod:: sed.stratplex.STRAMesh._depthPorosityDual

--- a/docs/api_ref/voro_ref.rst
+++ b/docs/api_ref/voro_ref.rst
@@ -18,54 +18,72 @@ Voronoi helper used by :class:`mesher.unstructuredmesh.UnstMesh` to build the Ce
 
    .. autosummary::
 
-      ~VoroBuild.angles
-      ~VoroBuild.cell_barycenters
-      ~VoroBuild.cell_centroids
-      ~VoroBuild.cell_circumcenters
-      ~VoroBuild.cell_partitions
-      ~VoroBuild.ce_ratios_per_interior_edge
-      ~VoroBuild.circumradius
-      ~VoroBuild.compute_curl
-      ~VoroBuild.control_volume_centroids
-      ~VoroBuild.control_volumes
-      ~VoroBuild.create_edges
-      ~VoroBuild.edge_gid_to_edge_list
       ~VoroBuild.edge_lengths
-      ~VoroBuild.edges_cells
-      ~VoroBuild.face_partitions
-      ~VoroBuild.inradius
-      ~VoroBuild.is_boundary_facet
+      ~VoroBuild.ce_ratios_per_interior_edge
+      ~VoroBuild.control_volumes
+      ~VoroBuild.surface_areas
+      ~VoroBuild.control_volume_centroids
+      ~VoroBuild.signed_cell_areas
+      ~VoroBuild.mark_boundary
       ~VoroBuild.is_boundary_node
       ~VoroBuild.is_interior_node
-      ~VoroBuild.mark_boundary
-      ~VoroBuild.signed_cell_areas
-      ~VoroBuild.surface_areas
+      ~VoroBuild.is_boundary_facet
+      ~VoroBuild.create_edges
+      ~VoroBuild.edges_cells
+      ~VoroBuild.edge_gid_to_edge_list
+      ~VoroBuild.face_partitions
+      ~VoroBuild.cell_partitions
+      ~VoroBuild.cell_circumcenters
+      ~VoroBuild.cell_centroids
+      ~VoroBuild.cell_barycenters
+      ~VoroBuild.inradius
+      ~VoroBuild.circumradius
       ~VoroBuild.triangle_quality
+      ~VoroBuild.angles
+      ~VoroBuild.compute_curl
+
+   .. rubric:: Private Methods
+
+   .. autosummary::
+
+      ~VoroBuild.__del__
+      ~VoroBuild._compute_edges_cells
+      ~VoroBuild._compute_integral_x
+      ~VoroBuild._compute_surface_areas
 
 Public functions
 ---------------------
 
 .. automethod:: mesher.meshfunc.VoroBuild.initVoronoi
-.. automethod:: mesher.meshfunc.VoroBuild.angles
-.. automethod:: mesher.meshfunc.VoroBuild.cell_barycenters
-.. automethod:: mesher.meshfunc.VoroBuild.cell_centroids
-.. automethod:: mesher.meshfunc.VoroBuild.cell_circumcenters
-.. automethod:: mesher.meshfunc.VoroBuild.cell_partitions
-.. automethod:: mesher.meshfunc.VoroBuild.ce_ratios_per_interior_edge
-.. automethod:: mesher.meshfunc.VoroBuild.circumradius
-.. automethod:: mesher.meshfunc.VoroBuild.compute_curl
-.. automethod:: mesher.meshfunc.VoroBuild.control_volume_centroids
-.. automethod:: mesher.meshfunc.VoroBuild.control_volumes
-.. automethod:: mesher.meshfunc.VoroBuild.create_edges
-.. automethod:: mesher.meshfunc.VoroBuild.edge_gid_to_edge_list
 .. automethod:: mesher.meshfunc.VoroBuild.edge_lengths
-.. automethod:: mesher.meshfunc.VoroBuild.edges_cells
-.. automethod:: mesher.meshfunc.VoroBuild.face_partitions
-.. automethod:: mesher.meshfunc.VoroBuild.inradius
-.. automethod:: mesher.meshfunc.VoroBuild.is_boundary_facet
+.. automethod:: mesher.meshfunc.VoroBuild.ce_ratios_per_interior_edge
+.. automethod:: mesher.meshfunc.VoroBuild.control_volumes
+.. automethod:: mesher.meshfunc.VoroBuild.surface_areas
+.. automethod:: mesher.meshfunc.VoroBuild.control_volume_centroids
+.. automethod:: mesher.meshfunc.VoroBuild.signed_cell_areas
+.. automethod:: mesher.meshfunc.VoroBuild.mark_boundary
 .. automethod:: mesher.meshfunc.VoroBuild.is_boundary_node
 .. automethod:: mesher.meshfunc.VoroBuild.is_interior_node
-.. automethod:: mesher.meshfunc.VoroBuild.mark_boundary
-.. automethod:: mesher.meshfunc.VoroBuild.signed_cell_areas
-.. automethod:: mesher.meshfunc.VoroBuild.surface_areas
+.. automethod:: mesher.meshfunc.VoroBuild.is_boundary_facet
+.. automethod:: mesher.meshfunc.VoroBuild.create_edges
+.. automethod:: mesher.meshfunc.VoroBuild.edges_cells
+.. automethod:: mesher.meshfunc.VoroBuild.edge_gid_to_edge_list
+.. automethod:: mesher.meshfunc.VoroBuild.face_partitions
+.. automethod:: mesher.meshfunc.VoroBuild.cell_partitions
+.. automethod:: mesher.meshfunc.VoroBuild.cell_circumcenters
+.. automethod:: mesher.meshfunc.VoroBuild.cell_centroids
+.. automethod:: mesher.meshfunc.VoroBuild.cell_barycenters
+.. automethod:: mesher.meshfunc.VoroBuild.inradius
+.. automethod:: mesher.meshfunc.VoroBuild.circumradius
 .. automethod:: mesher.meshfunc.VoroBuild.triangle_quality
+.. automethod:: mesher.meshfunc.VoroBuild.angles
+.. automethod:: mesher.meshfunc.VoroBuild.compute_curl
+
+
+Private functions
+---------------------
+
+.. automethod:: mesher.meshfunc.VoroBuild.__del__
+.. automethod:: mesher.meshfunc.VoroBuild._compute_edges_cells
+.. automethod:: mesher.meshfunc.VoroBuild._compute_integral_x
+.. automethod:: mesher.meshfunc.VoroBuild._compute_surface_areas

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,6 @@ import sphinx_rtd_theme
 from intersphinx_registry import get_intersphinx_mapping
 from numpydoc.docscrape_sphinx import SphinxDocString
 
-from mock import Mock as MagicMock
-
 try:
     # Available from Sphinx 2.0
     from sphinx.builders.dirhtml import DirectoryHTMLBuilder
@@ -38,6 +36,13 @@ except ImportError:
         SingleFileHTMLBuilder,
         StandaloneHTMLBuilder,
     )
+# Repo root so `import gospl` (and `from gospl.tools.constants import ...`, used
+# throughout the package) resolves — gospl is NOT pip-installed on Read the Docs,
+# so without this every module that imports from the `gospl` package failed to
+# import under autodoc and rendered as an EMPTY API page.
+sys.path.insert(0, os.path.abspath(".."))
+# `../gospl/` keeps the legacy top-level module paths (e.g. ``sed.hillslope``)
+# used by the ``.. autoclass::`` directives in docs/api_ref/*.rst.
 sys.path.insert(0, os.path.abspath("../gospl/"))
 
 # Redefine supported_image_types for the HTML builder
@@ -287,36 +292,25 @@ epub_title = project
 epub_exclude_files = ["search.html"]
 
 
-# -- Mock utils
-# utils contains binary (FORTRAN and C) code for the performance-sensitive
-# parts of Badlands. readthedocs can't compile or load this, so we mock it
-# out.
-# See also http://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-MOCK_MODULES = [
+# -- Mock the compiled / MPI-linked dependencies that Read the Docs cannot
+# install or load, so autodoc can import every gospl module to extract its
+# docstrings. autodoc_mock_imports also covers SUBMODULES (e.g. vtk.util,
+# gflex.f2d), which the previous manual ``sys.modules[m] = Mock()`` approach did
+# not — and that manual approach also shadowed packages docs/requirements.txt
+# DOES install (numpy, scipy, pandas, numpy-indexed, ruamel.yaml), breaking
+# e.g. ``from scipy.special import ...`` and rendering most API pages empty.
+# Those installed packages are now left REAL; only the genuinely-absent ones,
+# plus the in-tree compiled extension ``gospl._fortran``, are mocked.
+# See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports
+autodoc_mock_imports = [
     "h5py",
     "mpi4py",
-    "Cython",
-    "ruamel",
-    "ruamel.yaml",
-    "pandas",
-    "scipy",
     "petsc4py",
-    "scipy.interpolate",
     "vtk",
-    "vtk.util",
     "gflex",
+    "pyshtools",
+    "gospl._fortran",
 ]
-
-for m in MOCK_MODULES:
-    sys.modules[m] = Mock()
 
 
 def skip(app, what, name, obj, would_skip, options):

--- a/docs/user_guide/surfproc.rst
+++ b/docs/user_guide/surfproc.rst
@@ -79,6 +79,18 @@ Hillslope and marine deposition parameters
         g. ``offshore`` is the distance offshore (m) beyond which the clinoform-distance cap is no longer applied (default: 1.0e7),
         h. ``oFill`` is the minimum elevation (m) below which the priority-flood algorithm is not applied — used to skip deep ocean cells (default: -6000.0).
 
+        *Optional: marine/lake diffusion solver*
+
+        .. code:: yaml
+
+            diffusion:
+                # ... above keys ...
+                marineSolver: picard   # 'ts' (default) | 'picard'
+                picardSub: 10
+                picardIts: 2
+
+        By default the marine and lake non-linear diffusion is integrated with an adaptive non-linear PETSc time-stepper (``marineSolver: ts``). On large, stiff marine inputs this can dominate the run (the adaptive controller takes many sub-steps and stalls at the diffusivity threshold). The opt-in ``marineSolver: picard`` uses a **lagged-diffusivity** backward-Euler scheme instead: it takes ``picardSub`` sub-steps over the goSPL step (default 10), freezing the diffusivity within each and solving the resulting *linear* system with ``picardIts`` Picard updates (default 2). Each solve is linear (no non-linear stalls or step rejections), which is markedly faster on production meshes. It is an **approximation** — on small problems it matches the default solver almost exactly, but on large runs the deposit geometry differs slightly; increase ``picardSub`` to converge toward the time-stepper solution. The default remains ``ts``.
+
         The following parameters control how partial-fill deposition in **inland depressions** is distributed (see :ref:`dep`):
 
         .. code:: yaml

--- a/gospl/mesher/unstructuredmesh.py
+++ b/gospl/mesher/unstructuredmesh.py
@@ -994,6 +994,7 @@ class UnstMesh(object):
             "_ts_marine", "_ts_marine_x",
             "_smoothMat", "_ksp_smooth",
             "_hillMat", "_ksp_hill_lin",
+            "_ksp_picard",
             "_ts_soil", "_ts_soil_x", "_ts_soil_f",
         ):
             obj = getattr(self, name, None)

--- a/gospl/sed/hillslope.py
+++ b/gospl/sed/hillslope.py
@@ -51,6 +51,10 @@ class hillSLP(object):
         self._ts_marine = None
         self._ts_marine_x = None
 
+        # Lagged-diffusivity (Picard) alternative to the marine/lake diffusion
+        # TS (opt-in via self.marineSolver == 'picard'); cached linear KSP.
+        self._ksp_picard = None
+
         # Cached marine-morphology smoothing operator (_hillSlope smooth=2) and
         # its KSP. The smoothing diffusivity is mesh-size-based and timestep-
         # independent, so the operator depends only on the (fixed) mesh and the
@@ -241,13 +245,30 @@ class hillSLP(object):
             diffCoeffs[self.idBorders, 1:] = 0.0
             diffCoeffs[self.idBorders, 0] = 1.0
 
-        diffMat = self._matrix_build_diag(diffCoeffs[:, 0])
+        return self._assembleDiffMat(diffCoeffs)
+
+    def _assembleDiffMat(self, coeffs):
+        """
+        Assemble a PETSc finite-volume stencil matrix from a per-node
+        coefficient array ``coeffs`` of shape ``(lpoints, 1 + maxnb)``: column 0
+        is the diagonal, columns ``1..maxnb`` are the off-diagonal entries for
+        the ``maxnb`` neighbours in ``self.FVmesh_ngbID``. Used by
+        ``_buildDiffMat`` (``sethillslopecoeff`` output) and the lagged-
+        diffusivity marine solver (``jacobiancoeff`` output, scaled to
+        ``I + dt·L``).
+
+        :arg coeffs: ``(lpoints, 1+maxnb)`` diagonal + neighbour coefficients.
+
+        :return: the assembled PETSc matrix (caller owns / destroys it).
+        """
+
+        diffMat = self._matrix_build_diag(coeffs[:, 0])
         indptr = np.arange(0, self.lpoints + 1, dtype=petsc4py.PETSc.IntType)
 
         for k in range(0, self.maxnb):
             tmpMat = self._matrix_build()
             indices = self.FVmesh_ngbID[:, k].copy()
-            data = diffCoeffs[:, k + 1]
+            data = coeffs[:, k + 1]
             ids = np.nonzero(data == 0.0)
             indices[ids] = ids
             tmpMat.assemblyBegin()
@@ -261,6 +282,58 @@ class hillSLP(object):
             tmpMat.destroy()
 
         return diffMat
+
+    def _assembleDiffMatCSR(self, coeffs):
+        """
+        Single-pass CSR assembly of the FV stencil matrix from ``coeffs``
+        ``(lpoints, 1+maxnb)`` (col 0 = diagonal, cols ``1..maxnb`` = neighbour
+        entries for ``self.FVmesh_ngbID``). Equivalent to ``_assembleDiffMat``
+        (diag + per-neighbour axpy) but builds the matrix in ONE
+        ``setValuesLocalCSR`` pass — ``ADD_VALUES`` sums shared columns exactly,
+        mirroring ``seaplex._matOcean`` (#450). Much cheaper than the 12-axpy
+        loop, used in the Picard hot loop (`_diffuseImplicitPicard`), which
+        rebuilds the operator every iteration.
+
+        ``_buildDiffMat`` deliberately keeps the 12-axpy ``_assembleDiffMat`` so
+        the bit-faithful cached smoother / linear-hillslope operators (#457 /
+        #459) are not perturbed by a different floating-point summation order.
+
+        :arg coeffs: ``(lpoints, 1+maxnb)`` diagonal + neighbour coefficients.
+
+        :return: the assembled PETSc matrix (caller owns / destroys it).
+        """
+
+        nnz = 1 + self.maxnb
+        nodes = np.arange(self.lpoints, dtype=petsc4py.PETSc.IntType)
+        ngb = self.FVmesh_ngbID[:, : self.maxnb].astype(petsc4py.PETSc.IntType).copy()
+        offvals = coeffs[:, 1 : 1 + self.maxnb].copy()
+        # Redirect zero-valued neighbour entries to the diagonal so the column
+        # index is always valid (adds 0 under ADD_VALUES) — matches the
+        # `indices[ids] = ids` trick in _assembleDiffMat.
+        zero = offvals == 0.0
+        ngb[zero] = np.broadcast_to(nodes[:, None], ngb.shape)[zero]
+
+        cols = np.empty((self.lpoints, nnz), dtype=petsc4py.PETSc.IntType)
+        cols[:, 0] = nodes
+        cols[:, 1:] = ngb
+        vals = np.empty((self.lpoints, nnz), dtype=np.float64)
+        vals[:, 0] = coeffs[:, 0]
+        vals[:, 1:] = offvals
+        indptr = np.arange(
+            0, self.lpoints * nnz + 1, nnz, dtype=petsc4py.PETSc.IntType
+        )
+
+        M = self._matrix_build(nnz=(nnz, nnz))
+        M.assemblyBegin()
+        M.setValuesLocalCSR(
+            indptr,
+            cols.ravel(),
+            vals.ravel(),
+            addv=petsc4py.PETSc.InsertMode.ADD_VALUES,
+        )
+        M.assemblyEnd()
+
+        return M
 
     def _makeDiffusionKSP(self, prefix):
         """
@@ -628,6 +701,11 @@ class hillSLP(object):
         :return: ndepo - smoothed deposit thickness (m), zeroed where negative
         """
 
+        # Opt-in: lagged-diffusivity (Picard) linear solver instead of the
+        # adaptive non-linear TS (see _diffuseImplicitPicard). Default 'ts'.
+        if getattr(self, "marineSolver", "ts") == "picard":
+            return self._diffuseImplicitPicard(dh, mask, Cd_val, label=label)
+
         t0 = process_time()
 
         self.mat.zeroEntries()
@@ -719,5 +797,95 @@ class hillSLP(object):
         self.dm.globalToLocal(self.dh, self.tmpL)
         ndepo = self.tmpL.getArray().copy()
         ndepo[ndepo < 0.0] = 0.0
+
+        return ndepo
+
+    def _diffuseImplicitPicard(self, dh, mask, Cd_val, label="diffusion"):
+        r"""
+        Lagged-diffusivity (Picard) alternative to ``_diffuseImplicit`` for the
+        non-linear thickness diffusion :math:`\partial_t h = \nabla\cdot(C_d(h)
+        \nabla h)` over one model step.
+
+        Instead of the adaptive non-linear TS, this takes ``self.picardSub``
+        backward-Euler sub-steps of size ``dt/picardSub``; within each sub-step
+        it freezes the diffusivity :math:`C_d(h^k)` and solves the resulting
+        **linear** system :math:`(I + \Delta t_{sub} L(C_d^k)) h^{k+1} = h^{start}`
+        with ``self.picardIts`` Picard updates. The operator ``L`` is built from
+        ``jacobiancoeff`` with a zero derivative term (``Kp=0``), so it is the
+        exact linear :math:`\nabla\cdot(C_d\nabla)` operator consistent with the
+        TS residual ``fctcoeff`` — including the "no flux across a zero-
+        diffusivity face" marine-mask gating.
+
+        Each solve is linear (a cached richardson+bjacobi KSP, no SNES) and,
+        because :math:`C_d` is frozen, smooth — so it avoids the error-estimate
+        rejections the adaptive TS hits at the :math:`C_d` kink (``dh<0.1``).
+        ``picardSub`` is the accuracy/speed knob. Same signature / return as
+        ``_diffuseImplicit``.
+
+        :arg dh: per-node initial deposit thickness (m)
+        :arg mask: cells where diffusion is active
+        :arg Cd_val: scalar non-linear diffusion coefficient (m^2/yr)
+        :arg label: log label
+
+        :return: ndepo - smoothed deposit thickness (m), zeroed where negative
+        """
+
+        t0 = process_time()
+        nsub = int(getattr(self, "picardSub", 10))
+        npic = int(getattr(self, "picardIts", 2))
+        dt_sub = self.dt / nsub
+
+        Cd0 = np.zeros(self.lpoints)
+        Cd0[mask] = Cd_val
+        minDiff_vec = np.zeros(self.lpoints)
+        minDiff_vec[mask] = self.minDiff
+        zb = self.hLocal.getArray().copy()         # pre-deposition bed
+        zeroKp = np.zeros(self.lpoints)
+
+        # Deposited surface h = bed + dh (global self.h, local self.hl).
+        self.hl.setArray(dh)
+        self.hl.axpy(1.0, self.hLocal)
+        self.dm.localToGlobal(self.hl, self.h)
+
+        if self._ksp_picard is None:
+            self._ksp_picard = self._makeDiffusionKSP("marpicard_")
+        ksp = self._ksp_picard
+
+        nsolve = 0
+        for _ in range(nsub):
+            self.h.copy(result=self.tmp1)          # h^start (BE right-hand side)
+            for _ in range(npic):
+                self.dm.globalToLocal(self.h, self.hl)
+                hloc = self.hl.getArray()
+                dhdep = hloc - zb
+                dhdep[dhdep < 0.1] = 0.0
+                Cd = minDiff_vec + np.multiply(
+                    Cd0, 1.0 - np.exp(-self.dexp * dhdep)
+                )
+                # Linear operator L = div(Cd grad .) consistent with fctcoeff
+                # (Kp=0 -> no derivative term); 13-col (diag, 12 neighbours).
+                nlC = jacobiancoeff(hloc, Cd, zeroKp)
+                coeffs = dt_sub * nlC
+                coeffs[:, 0] += 1.0                # M = I + dt_sub * L
+                M = self._assembleDiffMatCSR(coeffs)
+                ksp.setOperators(M, M)
+                ksp.solve(self.tmp1, self.h)
+                M.destroy()
+                nsolve += 1
+
+        # Deposit thickness relative to the pre-deposition elevation.
+        self.dh.waxpy(-1.0, self.hGlobal, self.h)
+        self.dm.globalToLocal(self.dh, self.tmpL)
+        ndepo = self.tmpL.getArray().copy()
+        ndepo[ndepo < 0.0] = 0.0
+
+        if MPIrank == 0 and self.verbose:
+            print(
+                "Nonlinear diffusion (Picard %s, %0.02f seconds): %d linear "
+                "solves (%d sub-steps x %d Picard)"
+                % (label, process_time() - t0, nsolve, nsub, npic),
+                flush=True,
+            )
+        petsc4py.PETSc.garbage_cleanup()
 
         return ndepo

--- a/gospl/tools/inputparser.py
+++ b/gospl/tools/inputparser.py
@@ -512,6 +512,14 @@ class ReadYaml(object):
             # bottom-up baseline. 0.0 = pure bowl fill, 1.0 = original
             # inlet-only spike.
             self.nl_pit_inlet_bias = hillDict.get("pitInletBias", 0.10)
+            # Marine/lake non-linear-diffusion solver. 'ts' (default) = adaptive
+            # non-linear PETSc TS (rosw). 'picard' = lagged-diffusivity backward-
+            # Euler with linear solves (faster, robust at the C_d kink), an
+            # opt-in approximation; picardSub sub-steps over dt, picardIts Picard
+            # iterations per sub-step. See sed/hillslope._diffuseImplicitPicard.
+            self.marineSolver = str(hillDict.get("marineSolver", "ts")).lower()
+            self.picardSub = int(hillDict.get("picardSub", 10))
+            self.picardIts = int(hillDict.get("picardIts", 2))
         except KeyError:
             self.nlK = 10.0
             self.clinSlp = 1.0e-6
@@ -522,9 +530,16 @@ class ReadYaml(object):
             self.nl_pit_depth = 100.0
             self.nl_pit_K = self.nlK
             self.nl_pit_inlet_bias = 0.50
+            self.marineSolver = "ts"
+            self.picardSub = 10
+            self.picardIts = 2
 
         self.clinSlp = max(1.0e-6, self.clinSlp)
         self.nl_pit_inlet_bias = min(1.0, max(0.0, self.nl_pit_inlet_bias))
+        if self.marineSolver not in ("ts", "picard"):
+            self.marineSolver = "ts"
+        self.picardSub = max(1, self.picardSub)
+        self.picardIts = max(1, self.picardIts)
 
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,17 @@ def minimal_model():
 
 
 @pytest.fixture
+def minimal_picard_model():
+    """
+    Same as minimal_model but with the opt-in lagged-diffusivity (Picard)
+    marine/lake diffusion solver (`diffusion: marineSolver: picard`). Used to
+    test the opt-in parsing and that the Picard deposit matches the default TS
+    on the minimal fixture. See minimal_picard.yml.
+    """
+    return _instantiate("minimal_picard.yml")
+
+
+@pytest.fixture
 def minimal_strat_model():
     """
     Minimal model with stratigraphy recording ON (single-fraction). Baseline

--- a/tests/fixtures/minimal_picard.yml
+++ b/tests/fixtures/minimal_picard.yml
@@ -1,0 +1,34 @@
+name: minimal test (Picard marine solver)
+domain:
+  npdata:
+  - mesh
+  - v
+  - c
+  - z
+  flowdir: 2
+  bc: '1111'
+  seadepo: true
+  nodep: false
+time:
+  start: 0.0
+  end: 100
+  tout: 50
+  dt: 10.0
+spl:
+  K: 4.0e-06
+  d: 0.0
+  m: 0.5
+  G: 0.0
+diffusion:
+  hillslopeKa: 0.01
+  hillslopeKm: 0.2
+  marineSolver: picard
+  picardSub: 10
+  picardIts: 2
+sea:
+  position: -100.0
+climate:
+- start: 0.0
+  uniform: 1
+output:
+  dir: minimal_picard

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3363,6 +3363,66 @@ def test_marine_ts_step_counter_resets(minimal_model):
 
 
 # ---------------------------------------------------------------------------
+# TEST 8e - Opt-in lagged-diffusivity (Picard) marine solver
+# ---------------------------------------------------------------------------
+#
+# `diffusion: marineSolver: picard` selects hillslope._diffuseImplicitPicard
+# (lagged-diffusivity backward-Euler with linear solves) instead of the default
+# adaptive non-linear TS. It is an opt-in approximation: on the minimal fixture
+# it matches the TS deposit to ~1e-5; on large stiff marine inputs it is much
+# faster (no kink rejections) at a small deposit difference. This test checks
+# (a) the opt-in is parsed, (b) the Picard run conserves mass, and (c) its
+# deposit matches the default TS on the minimal fixture (closed sphere).
+# ---------------------------------------------------------------------------
+
+
+def test_marine_picard_solver(minimal_model, minimal_picard_model):
+    """
+    Protects: the opt-in `diffusion: marineSolver: picard` path
+    (inputparser._extraHillslope -> hillslope._diffuseImplicitPicard). Asserts
+    the flag is parsed, the Picard marine/lake diffusion conserves mass, and its
+    cumulative erosion/deposition matches the default TS solver on the minimal
+    closed-sphere fixture (the approximation is exact there).
+    """
+    mp = minimal_picard_model
+    assert getattr(mp, "marineSolver", "ts") == "picard", (
+        "diffusion.marineSolver: picard was not parsed into self.marineSolver"
+    )
+
+    def _run(m):
+        try:
+            m.runProcesses()
+            owned = m.inIDs == 1
+            ed = m.cumEDLocal.getArray()[owned]
+            la = m.larea[owned]
+            ednorm = float(np.sum(ed ** 2)) ** 0.5
+            vol = float(np.sum(ed * la))
+            act = float(np.sum(np.abs(ed) * la))
+            return ednorm, abs(vol) / max(act, 1.0e-30)
+        finally:
+            m.destroy()
+
+    if getattr(minimal_model, "flatModel", False):
+        pytest.skip("needs a closed sphere (flatModel=False) for mass conservation")
+
+    ed_pic, mass_pic = _run(mp)
+    ed_ts, mass_ts = _run(minimal_model)
+
+    # Mass conservation on the closed sphere (same gate as test_mass_conservation).
+    assert mass_pic < 1.0e-4, (
+        f"Picard marine solver breaks mass conservation (rel {mass_pic:.2e})."
+    )
+    # Deposit must match the default TS solver to a tight tolerance on the
+    # minimal fixture (the lagged-diffusivity approximation is exact here).
+    rel = abs(ed_pic - ed_ts) / max(ed_ts, 1.0e-30)
+    assert rel < 1.0e-2, (
+        f"Picard deposit diverges from the TS solver on the minimal fixture "
+        f"(cumED rel diff {rel:.2e} > 1e-2): ed_pic={ed_pic:.6e} "
+        f"ed_ts={ed_ts:.6e}. The opt-in approximation should be near-exact here."
+    )
+
+
+# ---------------------------------------------------------------------------
 # TEST 9 - Stratigraphy: deposition + compaction physics
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
Two commits.

## 1. perf(sea): opt-in lagged-diffusivity (Picard) marine/lake diffusion solver

The marine non-linear diffusion (`hillslope._diffuseImplicit`, adaptive `rosw` TS) is the single largest cost on production runs — **~55% of total wall** on the 658k-node earth model — because the adaptive controller takes ~60 sub-steps/step and stalls at the `Cd(h)` kink (`dh<0.1`). Profiling showed neither tolerance nor controller tuning helps (looser tol explodes rejections at the kink; tighter target doubles the sub-steps).

Adds an **opt-in** alternative, `_diffuseImplicitPicard`, selected by `diffusion: marineSolver: picard` (default `ts` = the existing TS, **byte-for-byte unchanged**). It integrates `dh/dt = div(Cd(h) grad h)` over the step with `picardSub` backward-Euler sub-steps, freezing `Cd` within each and solving the resulting **linear** system `(I + dt_sub·L) h = h_start` with `picardIts` Picard updates. The operator `L` is built from `jacobiancoeff(h, Cd, Kp=0)` — the exact linear `div(Cd grad)` operator **consistent with the TS residual `fctcoeff`**, including its "no flux across a zero-diffusivity face" marine-mask gating — and assembled in one pass by the new `_assembleDiffMatCSR` (mirrors seaplex #450). Each solve is linear (cached `richardson+bjacobi` KSP `marpicard_`, no SNES) and, with `Cd` frozen, smooth — so there are none of the kink-driven step rejections.

**Validated:** matches the default TS deposit to **~1e-5** on the minimal closed sphere (mass-conserving), and on the earth model gives a **~1.5% deposit difference at ~5–8× faster** marine diffusion (6.3 s vs ~30–50 s/step). `picardSub`/`picardIts` are the accuracy/speed knobs. `_ksp_picard` registered in `destroy_DMPlex`.

Refactor: extracted the 12-axpy stencil assembly into `_assembleDiffMat` (used by `_buildDiffMat`, **unchanged** → #457/#459 bit-faithful caches untouched); the Picard hot loop uses the faster single-pass `_assembleDiffMatCSR`.

Default behaviour unchanged (`marineSolver='ts'`). Parsing in `inputparser._extraHillslope` (validated/clamped). Guard `test_marine_picard_solver` (parses opt-in + mass conservation + TS-parity on minimal), fixture `minimal_picard.yml`, docs in `user_guide/surfproc.rst`. **Suite 70 passed, 1 skipped.**

> Note: whether to ever flip the default to `picard` is a separate decision that deserves a deposit-geometry eyeball on a real run — kept opt-in for now.

## 2. docs(api): fix empty Read the Docs API pages + list every class method

The autodoc API reference rendered **empty for most classes** on RTD. Two `conf.py` causes: (1) `gospl` wasn't importable (not pip-installed on RTD; only `../gospl/` on `sys.path`, not the repo root) so every `from gospl.tools.constants import …` failed under autodoc → blank page; (2) the manual `sys.modules[m]=Mock()` list shadowed the **installed** scipy/pandas/numpy-indexed with a submodule-broken Mock (`from scipy.special import …` failed) and had fallen behind (pyshtools/numpy_indexed never mocked).

Fix: add the repo root to `sys.path`; replace the manual mock with `autodoc_mock_imports` listing **only** the genuinely-absent compiled/MPI deps (`h5py, mpi4py, petsc4py, vtk, gflex, pyshtools, gospl._fortran`). Verified all 17 gospl modules import under a faithful autodoc-mock simulation.

Then audited **all 18** `api_ref/*.rst` against their source classes and listed **every** method in both the autosummary and automethod blocks (hand-maintained pages, source order, autosummary set == automethod set). A consistency check confirms every documented method exists in source and none are missing. AGENTS.md gains a "Docs / Read the Docs (autodoc)" section so the empty-pages regression can't return.