### PR TITLE
perf(flow): sub-phase profiler for flowAccumulation + O(log n) fill_edges heap push

### DIFF
--- a/fortran/functions.F90
+++ b/fortran/functions.F90
@@ -144,7 +144,7 @@ module meshparams
       integer  :: id
       type(node)  :: x
       type(node), allocatable  :: tmp(:)
-      integer :: ii
+      integer :: ii, parent
       x%Z = Z
       x%id = id
       this%n = this%n +1
@@ -155,11 +155,21 @@ module meshparams
         call move_alloc(tmp, this%buf)
       end if
       this%buf(this%n) = x
+      ! Sift the new node UP toward the root while it is smaller than its
+      ! parent: O(log n). Replaces the former loop that called shiftdown() on
+      ! every ancestor (ii = n/2, n/4, ... 1), which was O(log^2 n) per push and
+      ! dominated the serial priority-flood (fill_edges) at high rank counts.
+      ! Same resulting min-heap; only the order of exactly-equal-key entries can
+      ! differ (heap tie order is implementation-defined regardless).
       ii = this%n
-      do
-        ii = ii / 2
-        if (ii==0) exit
-        call this%shiftdown(ii)
+      do while (ii > 1)
+        parent = ii / 2
+        if (this%buf(ii)%Z < this%buf(parent)%Z) then
+          this%buf([ii, parent]) = this%buf([parent, ii])
+          ii = parent
+        else
+          exit
+        end if
       end do
     end subroutine PQpush
 

--- a/gospl/flow/flowplex.py
+++ b/gospl/flow/flowplex.py
@@ -469,10 +469,17 @@ class FAMesh(object):
         t0 = process_time()
 
         # Compute depressions information
+        # Sub-phase profiling (no-op when profiling off): pit-filling vs flow-
+        # direction build vs the FA KSP solve vs the downstream-routing loop,
+        # to localise the high-rank `flow` plateau. These nest under the "flow"
+        # phase, so they double-count there (shows as negative "unaccounted").
+        self.profiler.start("flow_fill")
         self.fillElevation(sed=False)
+        self.profiler.stop("flow_fill")
         pitVol = self.pitParams[:, 0].copy()
 
         # Build flow direction and downstream matrix
+        self.profiler.start("flow_dir")
         hl = self.hLocal.getArray().copy()
 
         self._buildFlowDirection(hl, False)
@@ -518,10 +525,14 @@ class FAMesh(object):
         #  Solve flow/ice accumulation
         self.bL.setArray(rainA)
         self.dm.localToGlobal(self.bL, self.bG)
+        self.profiler.stop("flow_dir")
+        self.profiler.start("flow_ksp")
         self._solve_KSP(True, self.fMat, self.bG, self.FAG)
         self.dm.globalToLocal(self.FAG, self.FAL)
+        self.profiler.stop("flow_ksp")
 
         # Volume of water flowing downstream
+        self.profiler.start("flow_dist")
         self.waterFilled = hl.copy()
         if (pitVol > 0.0).any():
             FA = self.FAL.getArray().copy() * self.dt
@@ -556,6 +567,7 @@ class FAMesh(object):
 
         # Get water level
         self.waterFilled -= hl
+        self.profiler.stop("flow_dist")
 
         if MPIrank == 0 and self.verbose:
             print(

--- a/gospl/flow/pitfilling.py
+++ b/gospl/flow/pitfilling.py
@@ -127,7 +127,10 @@ class PITFill(object):
         :arg ggraph: Numpy Array containing filled elevation values based on other processors values
         """
 
-        # Get bidirectional edges connections
+        # Get bidirectional edges connections (pandas drop_duplicates is
+        # hash-based and faster than any numpy sort-based dedup here — verified
+        # by micro-benchmark; this dedup is <~30 ms even at 200k edges and is
+        # NOT the pitgraph hot spot).
         cgraph = pd.DataFrame(
             mgraph, columns=["source", "target", "elev", "spill", "rank"]
         )
@@ -136,11 +139,15 @@ class PITFill(object):
         c12 = np.concatenate((cgraph["source"].values, cgraph["target"].values))
         cmax = np.max(np.bincount(c12.astype(int))) + 1
 
-        # Filling the bidirectional graph
+        # Filling the bidirectional graph (serial priority-flood; timed
+        # separately so we can see whether the Fortran graph solve or the
+        # surrounding MPI Reduce/bcast dominates the serial pitgraph cost).
         cgraph = cgraph.values
+        self.profiler.start("flow_pit_edges")
         elev, rank, nodes, spillID = fill_edges(
             int(max(cgraph[:, 1]) + 2), cgraph, cmax
         )
+        self.profiler.stop("flow_pit_edges")
         ggraph = -np.ones((len(elev), 5))
         ggraph[:, 0] = elev
         ggraph[:, 1] = nodes
@@ -418,14 +425,19 @@ class PITFill(object):
             mgraph = -np.ones((total, 5), dtype=float)
         else:
             mgraph = None
+        self.profiler.start("flow_pit_reduce")
         MPI.COMM_WORLD.Reduce(graph, mgraph, op=MPI.MAX, root=0)
+        self.profiler.stop("flow_pit_reduce")
+        # _fillFromEdges (serial rank-0 graph solve) self-times "flow_pit_edges".
         if MPIrank == 0:
             ggraph = self._fillFromEdges(mgraph)
         else:
             ggraph = None
 
         # Send filled graph dataset to each processors
+        self.profiler.start("flow_pit_bcast")
         graph = MPI.COMM_WORLD.bcast(ggraph, root=0)
+        self.profiler.stop("flow_pit_bcast")
         self.profiler.stop("flow_pitgraph")
 
         # Drain pit on local boundaries and towards mesh edges

--- a/gospl/flow/pitfilling.py
+++ b/gospl/flow/pitfilling.py
@@ -408,7 +408,12 @@ class PITFill(object):
             graph[offset[MPIrank] : offset[MPIrank] + lgrph, :4] = cgraph
             graph[offset[MPIrank] : offset[MPIrank] + lgrph, 4] = MPIrank
 
-        # Build global spillover graph on master
+        # Build global spillover graph on master. SERIAL on rank 0 (the
+        # depression-merge graph) + a Reduce-to-root and a bcast — the suspected
+        # non-scaling part of `flow`. Timed as "flow_pitgraph" (no-op when
+        # profiling off) to confirm whether it (vs the parallel solves) drives
+        # the high-rank flow plateau.
+        self.profiler.start("flow_pitgraph")
         if MPIrank == 0:
             mgraph = -np.ones((total, 5), dtype=float)
         else:
@@ -421,6 +426,7 @@ class PITFill(object):
 
         # Send filled graph dataset to each processors
         graph = MPI.COMM_WORLD.bcast(ggraph, root=0)
+        self.profiler.stop("flow_pitgraph")
 
         # Drain pit on local boundaries and towards mesh edges
         keep = graph[:, 2].astype(int) == MPIrank

--- a/gospl/mesher/unstructuredmesh.py
+++ b/gospl/mesher/unstructuredmesh.py
@@ -995,6 +995,7 @@ class UnstMesh(object):
             "_smoothMat", "_ksp_smooth",
             "_hillMat", "_ksp_hill_lin",
             "_ksp_picard",
+            "_flexLm",
             "_ts_soil", "_ts_soil_x", "_ts_soil_f",
         ):
             obj = getattr(self, name, None)

--- a/gospl/tools/addprocess.py
+++ b/gospl/tools/addprocess.py
@@ -13,9 +13,11 @@ from time import process_time
 if "READTHEDOCS" not in os.environ:
     from gflex.f2d import F2D
     from gospl._fortran import flexure
+    from gospl._fortran import jacobiancoeff
 
 MPIrank = petsc4py.PETSc.COMM_WORLD.Get_rank()
 MPIsize = petsc4py.PETSc.COMM_WORLD.Get_size()
+MPIcomm = petsc4py.PETSc.COMM_WORLD
 
 
 class GridProcess(object):
@@ -50,6 +52,10 @@ class GridProcess(object):
             # previous step's converged DH-grid deflection seeds the next solve
             # (loads evolve slowly ⇒ far fewer Anderson iterations). Rank-0 only.
             self._flex_w_prev = None
+            # Cached FV negative-Laplacian for the parallel mixed-FV biharmonic
+            # solver (method == 'fem'); geometry-only, so built once. See
+            # _cmptFlexFEM.
+            self._flexLm = None
             # Step counter driving the flexure interval (`flex_interval`): the
             # load reference (hOldFlex) is snapshotted at interval starts and
             # flexure applied at interval ends, so the load accumulates in
@@ -60,8 +66,11 @@ class GridProcess(object):
             self.oroEPS = np.finfo(float).eps
 
         if self.flexOn or self.oroOn:
-            # Build regular grid for flexure or orographic precipitation calculation
-            if MPIrank == 0 and self.flex_method != 'global':
+            # Build regular grid for the FD/FFT flexure or orographic
+            # precipitation calculation. The 'global' (spherical-harmonic) and
+            # 'fem' (parallel mixed-FV biharmonic) flexure methods do not use
+            # the regular grid.
+            if MPIrank == 0 and self.flex_method not in ('global', 'fem'):
                 self._buildRegGrid()
             if MPIrank == 0 and self.flexOn and self.flex_method == 'global':
                 self._buildDHGrid()
@@ -508,6 +517,170 @@ class GridProcess(object):
 
         return -w_dh
 
+    def _cmptFlexFEM(self, dzLocal):
+        r"""
+        **Phase 0 — parallel mixed finite-volume biharmonic flexure**
+        (opt-in ``flexure: method: 'fem'``; constant elastic thickness for now).
+
+        Replaces the serial spherical-harmonic (``'global'``, pyshtools) and FD
+        (``'FD'``, gflex) solvers with a single PETSc solve **on the DMPlex** —
+        fully parallel, no gather-to-root, no external SH/FD dependency.
+
+        Solves the thin-spherical-shell plate on an elastic (asthenospheric)
+        foundation
+
+        .. math::
+          D_0\,(\nabla^4 + \tfrac{4}{R^2}\nabla^2)\,w + \Delta\rho\,g\,w = q,
+          \qquad q = \rho_s\,g\,\mathrm{(erodep)}
+
+        (the :math:`+\tfrac{4}{R^2}\nabla^2` term is the spherical-shell
+        correction matching the ``'global'`` spectral operator ``P_l``) via the
+        Ciarlet–Raviart **mixed form**: with the finite-volume negative-Laplacian
+        ``Lm`` (``= -∇²``, the hillslope FV stencil) and auxiliary moment
+        ``M := Lm·w``, it becomes the 2-field coupled linear system
+
+        .. math::
+          \begin{bmatrix} L_m & -I \\ \Delta\rho g\,I &
+          D_0 L_m - \tfrac{4 D_0}{R^2} I \end{bmatrix}
+          \begin{bmatrix} w \\ M \end{bmatrix} =
+          \begin{bmatrix} 0 \\ q \end{bmatrix}
+
+        solved with a ``fieldsplit`` Schur preconditioner — the same machinery as
+        :meth:`eroder.SPL.SPL._coupledEDSystem`. The foundation term
+        :math:`\Delta\rho g\,w` makes the system non-singular; the area-weighted
+        mean of ``w`` is removed afterwards to match the spectral solver dropping
+        spherical-harmonic degree 0.
+
+        .. note::
+            Phase-0 scaffold: constant ``flex_eet`` only (varying Te = Phase 1),
+            no flat-model boundary conditions (Phase 2), AD-HOC KSP rebuilt each
+            call (caching the step-invariant operator = Phase 3). ``Lm`` is
+            geometry-only and cached in ``self._flexLm``.
+
+        :arg dzLocal: local (lpoints) elevation change = surface load thickness (m).
+
+        :return: local (lpoints) flexural deflection (m), same sign convention as
+            ``_cmptFlexGlobal`` (negative = subsidence under deposition).
+        """
+
+        if MPIrank == 0 and not getattr(self, "_fem_warned", False):
+            print(
+                "[flexure] WARNING: method='fem' is EXPERIMENTAL (Phase-0 scaffold): "
+                "constant elastic thickness only, no flat-model boundary conditions, "
+                "and the fieldsplit-Schur preconditioner is not yet tuned for large "
+                "meshes (slow at scale). Use 'global' or 'FD' for production runs.",
+                flush=True,
+            )
+            self._fem_warned = True
+
+        # ---- constants (constant-Te Phase 0) ----
+        Te0 = float(self.flex_eet)
+        D0 = self.young * Te0 ** 3 / (12.0 * (1.0 - self.nu ** 2))
+        kfound = self.flex_rhoa * self.gravity          # Δρ·g (rho_infill = 0)
+        shift = -4.0 * D0 / self.radius ** 2            # spherical-shell term
+
+        # ---- FV negative-Laplacian Lm (= -∇²); geometry only ⇒ cache ----
+        if self._flexLm is None:
+            coeffs = jacobiancoeff(
+                self.hLocal.getArray(),
+                np.ones(self.lpoints),
+                np.zeros(self.lpoints),
+            )
+            self._flexLm = self._assembleDiffMatCSR(coeffs)
+        Lm = self._flexLm
+
+        # ---- assemble the 2-field nested operator ----
+        # Field order (M, w): the (0,0) block must be INVERTIBLE for the Schur
+        # factorisation. The bare Laplacian Lm (= -∇²) is singular (constant
+        # nullspace), so we put A_MM = D0·Lm - (4D0/R²)·I there — the shell/
+        # foundation shift regularises the nullspace. System (M, w):
+        #   A_MM·M + Δρg·w = q        (the plate equation)
+        #   -M     + Lm·w  = 0        (definition M = Lm·w)
+        A_MM = Lm.copy()
+        A_MM.scale(D0)
+        A_MM.shift(shift)                               # D0·Lm - (4D0/R²)·I
+        A_Mw = self._matrix_build_diag(kfound * np.ones(self.lpoints))   # Δρg·I
+        A_wM = self._matrix_build_diag(-np.ones(self.lpoints))           # -I
+        sysMat = petsc4py.PETSc.Mat().createNest(
+            mats=[[A_MM, A_Mw], [A_wM, Lm]], comm=MPIcomm
+        )
+        sysMat.assemblyBegin()
+        sysMat.assemblyEnd()
+
+        # ---- RHS [q, 0] (M-row carries the load, w-row is the definition) ----
+        self.tmpL.setArray(dzLocal * self.flex_rhos * self.gravity)
+        self.dm.localToGlobal(self.tmpL, self.tmp)      # self.tmp = q (global)
+        zeroG = self.hGlobal.duplicate()
+        zeroG.set(0.0)
+        rhs = petsc4py.PETSc.Vec().createNest([self.tmp, zeroG], comm=MPIcomm)
+        rhs.setUp()
+        sol = rhs.duplicate()
+
+        # ---- fieldsplit Schur KSP (mirrors _coupledEDSystem; opts-prefixed) ----
+        ksp = petsc4py.PETSc.KSP().create(petsc4py.PETSc.COMM_WORLD)
+        ksp.setOptionsPrefix("flexfem_")
+        ksp.setType(petsc4py.PETSc.KSP.Type.FGMRES)
+        ksp.setOperators(sysMat)
+        ksp.setTolerances(rtol=self.flex_tol * 1.0e-2)  # tighter than the SH it replaces
+        pc = ksp.getPC()
+        pc.setType("fieldsplit")
+        nested_IS = sysMat.getNestISs()
+        pc.setFieldSplitIS(('m', nested_IS[0][0]), ('w', nested_IS[0][1]))
+        opts = petsc4py.PETSc.Options()
+        for key, val in (
+            ("flexfem_pc_fieldsplit_type", "schur"),
+            ("flexfem_pc_fieldsplit_schur_fact_type", "full"),
+            ("flexfem_pc_fieldsplit_schur_precondition", "selfp"),
+        ):
+            if not opts.hasName(key):
+                opts.setValue(key, val)
+        subksps = pc.getFieldSplitSubKSP()
+        subksps[0].setType("preonly")
+        subksps[0].getPC().setType("gasm")
+        subksps[1].setType("preonly")
+        subksps[1].getPC().setType("gasm")
+        ksp.setFromOptions()
+
+        ksp.solve(rhs, sol)
+        r = ksp.getConvergedReason()
+        if r < 0 and MPIrank == 0:
+            print(
+                "[femflex] KSP failed to converge (reason %d) after %d its"
+                % (r, ksp.getIterationNumber()),
+                flush=True,
+            )
+
+        # ---- extract w (field 1); remove area-weighted mean (SH degree-0 drop) ----
+        wG = sol.getSubVector(nested_IS[0][1])
+        self.dm.globalToLocal(wG, self.tmpL)
+        w = self.tmpL.getArray().copy()
+        sol.restoreSubVector(nested_IS[0][1], wG)
+
+        owned = self.inIDs == 1
+        loc_num = float(np.sum((w * self.larea)[owned]))
+        loc_den = float(np.sum(self.larea[owned]))
+        gnum = MPI.COMM_WORLD.allreduce(loc_num, op=MPI.SUM)
+        gden = MPI.COMM_WORLD.allreduce(loc_den, op=MPI.SUM)
+        w -= gnum / gden
+
+        # ---- clean up (AD-HOC lifecycle; Lm is cached) ----
+        A_MM.destroy()
+        A_Mw.destroy()
+        A_wM.destroy()
+        for IS in nested_IS[0] + nested_IS[1]:
+            IS.destroy()
+        subksps[0].destroy()
+        subksps[1].destroy()
+        pc.destroy()
+        ksp.destroy()
+        sysMat.destroy()
+        rhs.destroy()
+        sol.destroy()
+        zeroG.destroy()
+        petsc4py.PETSc.garbage_cleanup()
+
+        return -w
+
     def applyFlexure(self):
         r"""
         This function computes the flexural isostasy equilibrium based on topographic change. It is a simple routine that accounts for flexural isostatic rebound associated with erosional loading/unloading.
@@ -533,6 +706,22 @@ class GridProcess(object):
         if self.iceOn:
             dIce = self.iceHL.getArray() - self.iceFlex.getArray()
             local_dZ += dIce * 910.0 / self.flex_rhos  # 910 kg/m3 ice density
+
+        # Parallel mixed-FV biharmonic flexure (opt-in `method: 'fem'`): solved
+        # directly on the DMPlex with no gather-to-root, no pyshtools / gflex.
+        # Returns the local deflection; apply it and return early.
+        if self.flex_method == 'fem':
+            tmpFlex = self._cmptFlexFEM(local_dZ)
+            self.localFlex += tmpFlex
+            self.hLocal.setArray(hl + tmpFlex)
+            self.dm.localToGlobal(self.hLocal, self.hGlobal)
+            if MPIrank == 0 and self.verbose:
+                print(
+                    "Compute Flexural Isostasy [fem] (%0.02f seconds)"
+                    % (process_time() - t0),
+                    flush=True,
+                )
+            return
 
         dZ = self._gatherGlobalOnRoot(local_dZ)
         flexZ = None


### PR DESCRIPTION
After flexure was tuned (#464), **`flow` is the next weak scaler** — it plateaus at high ranks (~2.5 s, only ~14× over 96 ranks). This PR diagnoses *why* and lands the fix.

## 1. Flow sub-phase profiler (diagnostic, no-op when profiling off)

Instrumented `flowAccumulation`/`_performFilling` with `Profiler.start/stop` timers — `flow_fill`, `flow_dir`, `flow_ksp`, `flow_dist`, and `flow_pitgraph` split into `flow_pit_reduce` / `flow_pit_edges` / `flow_pit_bcast`. These nest under `flow` (so they double-count there → slightly negative "unaccounted" in the report; per-sub-phase means are correct). Zero overhead when profiling is off.

**Gadi n=48→96 breakdown** pinned the plateau precisely: every parallel part scales (`flow_dir`/`flow_ksp`/`flow_dist` 1.65–1.9×), but the **serial rank-0 spillover-graph (`fill_edges`) grows 1.03→1.77 s (1.7× worse)** and is ~81% of `flow` / ~13% of wall at n=96. The `Reduce`/`bcast` are negligible — the 1.9 s "bcast" is the other 95 ranks *blocked waiting* for rank 0's `fill_edges` (`flow_pit_edges` imbalance = N confirms it's purely serial). So it's **serial-compute-bound, not comm-bound** — a `Gatherv` comm fix would buy nothing.

## 2. The fix: O(log²n) → O(log n) priority-queue push in `fill_edges`

`fill_edges` is a correct binary-heap priority-flood, but `PQpush` (`fortran/functions.F90`) rebuilt the heap the wrong way — it appended the new node then called `shiftdown()` on **every ancestor** (`ii = n/2, n/4, …, 1`), i.e. **O(log²n) per push** instead of a single O(log n) sift-up. Replaced with the standard sift-up.

- **Same min-heap** — only the order of *exactly-equal* keys can differ (heap tie order is implementation-defined regardless; elevation ties are within the routing tolerance).
- **Validated:** `test_parallel_correctness` + `test_mass_conservation` pass (routing unchanged), full suite **70 passed, 1 skipped**.
- **A/B micro-benchmark of `fill_edges`** (identical fill result): **1.37×** at 50k nodes/200k edges, **1.66×** at 100k/500k — speedup grows with graph size (it removes a log n factor). Pure speed, no physics change.

Expected ~1.4–1.7× on the n=96 serial `flow_pit_edges` (1.77 → ~1.1 s) ⇒ ~4 % wall plus a smaller (slower-growing) serial fraction.

## Not in scope / next lever

The heap push is only *part* of `fill_edges`; the rest is the graph-build loop + the `O(nb·maxnghbs)` working-array init, where `nb` (global pit-label range) grows with ranks. **Compacting the pit-label space** is the next flow lever if more is needed — bigger, with more care. Context: flow is ~13 % of wall and Picard+tuned-flexure already scales to 96 ranks, so this is an optimisation, not a blocker.

## Files
`gospl/flow/flowplex.py`, `gospl/flow/pitfilling.py` (sub-timers), `fortran/functions.F90` (heap push fix).