### PR TITLE
perf(flow): drop dead O(nb*maxnghbs) array inits in fill_edges

### DIFF
--- a/fortran/functions.F90
+++ b/fortran/functions.F90
@@ -2428,20 +2428,24 @@ subroutine fill_edges(nb, cgraph, maxnghbs, nelev, spillrank, spillnodes, spilli
   double precision :: spill(nb,maxnghbs)
   double precision :: spillz(nb)
 
-  ! Initialise graph as a mesh
+  ! Initialise graph as a mesh.
+  ! NB: the dense (nb x maxnghbs) arrays ngbhArr/spill/spillnode/rank are NOT
+  ! pre-filled. The build loop below populates entries (c, 1..ngbNb(c)) and the
+  ! priority-flood only ever reads those same entries (do k = 1, ngbNb(c)), so a
+  ! full init is dead work. At high rank counts these fills are O(nb*maxnghbs)
+  ! and grow with the number of partition boundaries, so skipping them matters.
+  ! Only the O(nb) vectors are initialised — ranknode/spillz/inFlag/nelev and the
+  ! spill* outputs are read at indices the build loop may not populate, so they
+  ! must stay. tmp is written before read, so it needs no init either.
   inFlag = .False.
   ngbNb = 0
-  ngbhArr = -1
   spillnodes = -1
   spillrank = -1
   nelev = 1.e8
   nelev(1) = -1.e8
-  spillnode = -1
   spillz = 1.e8
   ranknode = -1
   spillid = -1
-  rank = -1
-  tmp = -1
   do k = 1, m
     n1 = int(cgraph(k,1))+1
     n2 = int(cgraph(k,2))+1


### PR DESCRIPTION
Follow-up to #465. The Gadi A/B on #465 showed the heap-push fix landed correctly but did **not** move the real earth run: `flow_pit_edges` is rank-0-only (`imbal == nranks`), with rank-0 time **1.0 s@48 → 1.8 s@96** — unchanged. The cost that grows with ranks is the *per-call setup* of the serial priority-flood, not the heap.

## Change

`fill_edges` pre-filled four dense `(nb × maxnghbs)` arrays — `ngbhArr`, `spill`, `spillnode`, `rank` — with sentinel values before building the spillover graph. But the build loop populates entries `(c, 1..ngbNb(c))` and the flood **only ever reads those same entries** (`do k = 1, ngbNb(c)`), so the pre-fill is dead work. At high rank counts these fills are `O(nb·maxnghbs)` and grow with the number of partition boundaries (more pit labels) — exactly the rank-growing cost the profiler localised.

Only the `O(nb)` vectors that are genuinely read at unpopulated indices are kept (`ranknode`/`spillz`/`inFlag`/`nelev` + the `spill*` outputs); `tmp` is written before read so it needs no init either.

## Validation

No physics change — identical fill result. `test_parallel_correctness` + `test_mass_conservation` pass; full suite **70 passed, 1 skipped**.

## Next flow lever (not in scope)

The remaining `fill_edges` growth is the `O(m)` graph-build loop and `maxnghbs` itself rising with ranks. The real fix is to **compact the global pit-label space** so `nb`/`maxnghbs` stop growing — larger, deferred.