### PR TITLE
perf(flow): compact pit labels before the serial priority-flood

### DIFF
--- a/gospl/flow/pitfilling.py
+++ b/gospl/flow/pitfilling.py
@@ -136,26 +136,60 @@ class PITFill(object):
         )
         cgraph = cgraph.sort_values("elev")
         cgraph = cgraph.drop_duplicates(["source", "target"], keep="first")
-        c12 = np.concatenate((cgraph["source"].values, cgraph["target"].values))
-        cmax = np.max(np.bincount(c12.astype(int))) + 1
+        cgraph = cgraph.values
+
+        # --- Pit-label compaction --------------------------------------------
+        # source/target are globally-offset pit labels (disjoint per rank), so
+        # the label space is SPARSE and its maximum grows ~linearly with the
+        # rank count even though the number of distinct spillover pits is far
+        # smaller. fill_edges sizes its O(nb) / O(nb*maxnghbs) work arrays from
+        # that maximum (nb = max(label)+2), so the serial solve grows with
+        # ranks. Relabel to a dense [0, nlab) space, solve there, then scatter
+        # the results back onto the global label index the downstream code
+        # expects. Label 0 (the global outlet, == node 1, the priority-flood
+        # seed) is the smallest label so it always maps to compact 0; union it
+        # in explicitly in case no edge references it directly. This is a pure
+        # relabeling: the fill result is identical to solving in global space.
+        nb_global = int(cgraph[:, 1].max()) + 2
+        src = cgraph[:, 0].astype(np.int64)
+        tgt = cgraph[:, 1].astype(np.int64)
+        uniq = np.unique(np.concatenate((src, tgt)))
+        if uniq[0] != 0:
+            uniq = np.concatenate((np.array([0], dtype=uniq.dtype), uniq))
+        nlab = len(uniq)
+        ccgraph = cgraph.copy()
+        ccgraph[:, 0] = np.searchsorted(uniq, src)
+        ccgraph[:, 1] = np.searchsorted(uniq, tgt)
+        c12 = ccgraph[:, :2].astype(int).ravel()
+        cmax = np.max(np.bincount(c12)) + 1
 
         # Filling the bidirectional graph (serial priority-flood; timed
         # separately so we can see whether the Fortran graph solve or the
         # surrounding MPI Reduce/bcast dominates the serial pitgraph cost).
-        cgraph = cgraph.values
+        # nlab+1 always covers every compact label 0..nlab-1 (the +1 keeps the
+        # one-node slack the global formula had).
         self.profiler.start("flow_pit_edges")
-        elev, rank, nodes, spillID = fill_edges(
-            int(max(cgraph[:, 1]) + 2), cgraph, cmax
-        )
+        elev, rank, nodes, spillID = fill_edges(nlab + 1, ccgraph, cmax)
         self.profiler.stop("flow_pit_edges")
-        ggraph = -np.ones((len(elev), 5))
-        ggraph[:, 0] = elev
-        ggraph[:, 1] = nodes
-        ggraph[:, 2] = rank
-        ggraph[:, 3] = spillID
+
+        # Scatter compact results back to the global label index. Labels with
+        # no spillover edge are absent from the compact graph; in global space
+        # fill_edges would have left them at its nelev sentinel (1e8), which the
+        # caller rewrites to MISSING_DATA_SENTINEL — reproduce that default so
+        # behaviour is identical. spillID is itself a (compact) label, so map it
+        # back to the global label too (nodes/rank are mesh ids, not labels).
+        ggraph = -np.ones((nb_global, 5))
+        ggraph[:, 0] = 1.0e8
+        ggraph[uniq, 0] = elev[:nlab]
+        ggraph[uniq, 1] = nodes[:nlab]
+        ggraph[uniq, 2] = rank[:nlab]
+        gspill = spillID[:nlab].astype(np.int64)
+        valid = (gspill >= 0) & (gspill < nlab)
+        gspill[valid] = uniq[gspill[valid]]
+        ggraph[uniq, 3] = gspill
         if self.memclear:
-            del elev, nodes, rank
-            del spillID, c12
+            del elev, nodes, rank, spillID
+            del src, tgt, uniq, c12, gspill, ccgraph
 
         return ggraph
 


### PR DESCRIPTION
Third and final lever on the serial pit-graph (after #465 profiler/heap-push and #466 dead-init removal). This one attacks the cost that actually grows with rank count.

## Problem

The spillover graph handed to `fill_edges` uses **globally-offset** pit labels — `_offsetGlobal` gives each rank a disjoint label range, so the label space is *sparse* and its maximum grows ~linearly with the rank count, even though the number of distinct spillover pits is far smaller. `fill_edges` sizes its `O(nb)` work arrays from that maximum (`nb = max(label)+2`), so the serial rank-0 solve grows with ranks — the dominant, rank-growing part of the flow pit-graph (`flow_pit_edges` rank-0 **1.0 s@48 → 1.8 s@96**, `imbal == nranks`).

## Change (Python-only, `_fillFromEdges`)

Relabel `source`/`target` to a dense `[0, nlab)` space with `np.unique` + `searchsorted`, solve the priority-flood there, then scatter the results back onto the global label index the downstream code expects. Details:
- Label 0 (the global outlet, i.e. `fill_edges` node 1 / the flood seed) is the smallest label, so it always maps to compact 0; it's unioned in explicitly in case no edge references it.
- `nlab+1` always covers every compact label (keeps the original one-node slack).
- `spillID` is itself a (compact) label → mapped back through `uniq`; `nodes`/`rank` are mesh ids, not labels, so they scatter directly.
- Global labels with no spillover edge are restored to the `fill_edges` `nelev` default (`1e8`, which the caller already rewrites to `MISSING_DATA_SENTINEL`) so untouched entries behave exactly as before.

This is a **pure relabeling — no physics change.** The expensive solve runs in compact space; only the cheap 5-column output reconstruction touches the global `nb`.

## Validation

- Full suite **70 passed, 1 skipped**.
- `test_parallel_correctness` (`mpirun -n 1` vs `-n 2`) passes.
- **New-vs-`dev` A/B at `n=2`: bit-for-bit identical** (max relative diff `0.0`) across 8 global fingerprints — weighted-mean elevation, ED flux, |ED| activity, Σh², max/Σ flow-accumulation, max elevation.

## Measurement note

Payoff scales with label sparsity, so it only shows at high rank counts (no local multi-node proxy) — the real number comes from the next Gadi sweep. Can't regress (smaller arrays, identical result).

## Remaining

The `O(m)` graph-build loop and the `(total,5)` `Reduce`/`bcast` still grow with ranks; a genuinely distributed Barnes-2016 master solve is the next, larger step (research-grade, separate WIP).