### PR TITLE
perf(flow): Barnes-faithful pit-label unification — union-find + Allgatherv

### DIFF
--- a/gospl/flow/pitfilling.py
+++ b/gospl/flow/pitfilling.py
@@ -300,12 +300,20 @@ class PITFill(object):
             )
         t0 = process_time()
 
-        # Send depression IDs globally
-        offset, _ = self._offsetGlobal(len(df))
-        combIds = -np.ones((np.amax(offset), 2), dtype=int)
-        if len(df) > 0:
-            combIds[offset[MPIrank] : offset[MPIrank + 1], :] = df.values
-        MPI.COMM_WORLD.Allreduce(MPI.IN_PLACE, combIds, op=MPI.MAX)
+        # Gather every rank's equivalence pairs onto all ranks. Allgatherv of
+        # the real pairs (Barnes-style) replaces a padded Allreduce(MAX) over a
+        # (total, 2) array — same content, no -1 padding to move. All ranks then
+        # run the identical union-find.
+        offset, total = self._offsetGlobal(len(df))
+        sendbuf = (
+            df.values.astype(np.int64).ravel()
+            if len(df) > 0
+            else np.empty(0, dtype=np.int64)
+        )
+        counts = (np.diff(offset) * 2).astype(int)
+        recvbuf = np.empty(int(total) * 2, dtype=np.int64)
+        MPI.COMM_WORLD.Allgatherv(sendbuf, [recvbuf, counts])
+        combIds = recvbuf.reshape(-1, 2)
         df = self._buildPitDataframe(combIds[:, 0], combIds[:, 1])
         df = df[(df["p1"] >= 0) & (df["p2"] >= 0)]
         if MPIrank == 0 and self.verbose:

--- a/gospl/flow/pitfilling.py
+++ b/gospl/flow/pitfilling.py
@@ -96,12 +96,80 @@ class PITFill(object):
         :arg df: Pandas Dataframe containing depression numbers which have to be combined.
 
         :return: df sorted pandas dataframe containing depression numbers.
+
+        .. note::
+            Superseded by :meth:`_unifyLabels` (union-find). Kept for reference
+            / the standalone sort_ids kernel; no longer on the hot path.
         """
 
         df["p2"] = sort_ids(df["p1"].values.astype(int), df["p2"].values.astype(int))
         df = df.drop_duplicates().sort_values(["p2", "p1"], ascending=(False, False))
 
         return df
+
+    def _unifyLabels(self, df, label):
+        """
+        Collapse cross-processor depression-label equivalence pairs into one
+        canonical id per connected component using union-find (disjoint-set),
+        then apply the mapping to ``label``.
+
+        ``df`` holds the global equivalence pairs ``(p1, p2)`` with ``p1 < p2``
+        (two labels that are the same depression across a tile border). Each
+        connected component is collapsed to its MINIMUM label by keeping the
+        smaller label as the set root — matching the previous iterative
+        ``sort_ids`` fixpoint, but in a single deterministic O(N α(N)) pass.
+        Determinism (root = min, independent of pair order) is what makes the
+        result identical regardless of the domain partition.
+
+        :arg df: Dataframe of equivalence pairs, columns ``p1`` < ``p2``.
+        :arg label: local depression-label array (globally-offset ids).
+
+        :return: ``label`` with every label remapped to its component minimum.
+        """
+
+        pairs = df[["p1", "p2"]].values.astype(np.int64)
+
+        # Union-find over the (sparse, globally-offset) labels that appear in a
+        # pair. Most mesh labels never cross a border, so the structure is small.
+        parent = {}
+
+        def find(x):
+            root = x
+            while parent[root] != root:
+                root = parent[root]
+            while parent[x] != root:  # path compression
+                parent[x], x = root, parent[x]
+            return root
+
+        for a, b in pairs:
+            a, b = int(a), int(b)
+            if a not in parent:
+                parent[a] = a
+            if b not in parent:
+                parent[b] = b
+            ra, rb = find(a), find(b)
+            if ra != rb:
+                # smaller label becomes the root → component minimum is canonical
+                if ra < rb:
+                    parent[rb] = ra
+                else:
+                    parent[ra] = rb
+
+        if not parent:
+            return label
+
+        # Vectorised remap: only labels appearing in a pair change; all others
+        # (the vast majority, plus the -1 border sentinel) pass through.
+        keys = np.fromiter(sorted(parent), dtype=np.int64, count=len(parent))
+        vals = np.fromiter((find(int(k)) for k in keys), dtype=np.int64,
+                           count=len(keys))
+        idx = np.searchsorted(keys, label)
+        idx_clip = np.clip(idx, 0, len(keys) - 1)
+        hit = keys[idx_clip] == label
+        out = label.copy()
+        out[hit] = vals[idx_clip[hit]]
+
+        return out
 
     def _offsetGlobal(self, lgth):
         """
@@ -246,24 +314,15 @@ class PITFill(object):
             )
         t0 = process_time()
 
-        # Sorting label transfer between processors
-        if len(df) > 1:
-            sorting = True
-            stp = 0
-            while sorting:
-                df2 = self._sortingPits(df)
-                sorting = not df.equals(df2)
-                df = df2.copy()
-                stp += 1
-                if stp > 1000:
-                    if MPIrank == 0:
-                        print(
-                            "Pit sorting did not converge after 1000 iterations; continuing.",
-                            flush=True,
-                        )
-                    break
-        for k in range(len(df)):
-            label[label == df["p2"].iloc[k]] = df["p1"].iloc[k]
+        # Collapse the cross-processor label-equivalence pairs (p1 < p2) into a
+        # single canonical id per connected component with union-find. This is
+        # Barnes-style label unification: the canonical id is the MINIMUM label
+        # in each component, identical to the previous iterative sort_ids
+        # fixpoint but in a single deterministic pass — no convergence loop (the
+        # old code iterated up to 1000 times) and no partition-dependent
+        # ordering, which removes the instability that forced the serial path.
+        if len(df) > 0:
+            label = self._unifyLabels(df, label)
         if MPIrank == 0 and self.verbose:
             print(
                 "Sorting pits (%0.02f seconds)" % (process_time() - t0)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -963,6 +963,40 @@ def test_ice_flexure_loading(minimal_ice_flex_model):
                 assert field in hf, f"ice output field {field} not in output"
 
 
+def test_pit_unifyLabels_unionfind():
+    """
+    Protects: PITFill._unifyLabels — the union-find that collapses cross-rank
+    depression-label equivalence pairs to one canonical id per connected
+    component (replacing the iterative sort_ids fixpoint). Guarantees:
+      - canonical id is the component MINIMUM (deterministic, partition-free),
+      - multi-hop chains and merges-via-shared-node fully collapse,
+      - labels not in any pair (and the -1 border sentinel) pass through.
+    Pure function (self unused), so call it unbound with no Model/mesh.
+    """
+    pitfilling = pytest.importorskip("gospl.flow.pitfilling")
+    PITFill = pitfilling.PITFill
+
+    def unify(pairs, label):
+        df = (pd.DataFrame(pairs, columns=["p1", "p2"]) if pairs
+              else pd.DataFrame({"p1": [], "p2": []}))
+        return PITFill._unifyLabels(None, df, np.asarray(label, dtype=int))
+
+    # multi-hop chain 1-4-7 collapses to min (1); separate comp {2,6}->2;
+    # merge via shared node 8: {3,5,8}->3; lone label 9 and -1 unchanged.
+    label = np.array([1, 4, 7, 2, 6, 3, 5, 8, 9, -1])
+    expected = np.array([1, 1, 1, 2, 2, 3, 3, 3, 9, -1])
+    out = unify([(1, 4), (4, 7), (2, 6), (3, 8), (5, 8)], label)
+    assert np.array_equal(out, expected), f"{out} != {expected}"
+
+    # order/direction independence: shuffled pairs (some p1>p2) give the same
+    # canonical mapping — union-find is symmetric and roots to the component min.
+    out2 = unify([(5, 8), (8, 3), (7, 4), (4, 1), (6, 2)], label)
+    assert np.array_equal(out2, expected), f"{out2} != {expected}"
+
+    # empty pair set is a no-op
+    assert np.array_equal(unify([], label), label)
+
+
 def _strata_parser(stratNb):
     """
     Bare parser primed for `_extraStrata`: it reads `self.input`,


### PR DESCRIPTION
Tightens the Phase-2 (master) side of the Barnes (2016) parallel priority-flood to match the algorithm faithfully and remove the fragile iterative step that originally forced the serial fallback. **No physics change** — bit-for-bit identical to `dev` at every rank count.

## 1. Union-find label unification (the stability fix)

`_transferIDs` unified cross-processor depression labels by iterating `sort_ids` to a fixpoint (**up to 1000 passes**) and applying the merge with a per-row Python loop. That iterative relabel is order-sensitive — the partition-dependent, oscillation-prone step behind the original instability.

Replaced with `_unifyLabels`: a single deterministic **union-find** over the global equivalence pairs, collapsing each connected component to its **minimum** label (the same canonical the `sort_ids` fixpoint converged to), applied vectorised via `searchsorted`. Deterministic by construction (root = component min, independent of pair order) → partition-independent, which is exactly the property Barnes-style unification needs. `_sortingPits` kept (no longer on the hot path).

## 2. Allgatherv the equivalence pairs (Barnes comm)

The pairs were shared via a `(total,2)` array padded with −1 and `Allreduce(MAX)`. Replaced with an `Allgatherv` of the real pairs (Barnes producer→all gather) — same content (labels ≥ 0, so MAX was exact), no padding moved.

## Deliberately NOT changed: the graph `Reduce(MAX)`

The Phase-2 spillover-graph gather is left as-is: `flow_pit_reduce` measures **~0.01 s and does not grow with ranks** (not a bottleneck), and its −1-padded column 2 (spill elevation) *clamps* sub-(−1 m) deep-ocean spills — currently harmless (below-sea fills are reverted downstream) but a subtlety a Gatherv would change. Not worth the validation burden for 0.01 s. The serial rank-0 `fill_edges` master solve stays serial **by design** — that is Barnes, not a compromise.

## Validation
- `dev`-n1 vs branch-n1 = **0.0**; `dev`-n2 vs branch-n2 = **0.0** (bit-for-bit at fixed rank count).
- n=1-vs-n=2 gap (5.82e-3) is identical on `dev` and branch → pre-existing model MPI non-determinism, untouched.
- `test_parallel_correctness` (n=1 vs n=2) + `test_mass_conservation` pass.
- New unit test `test_pit_unifyLabels_unionfind`: multi-hop chains, merge-via-shared-node, order independence, pass-through of unpaired labels + the −1 sentinel.
- Full suite **71 passed, 1 skipped**.