### PR TITLE
docs: remove cyclic-boundary references (not user-ready)

### DIFF
--- a/docs/tech_guide/tecto.rst
+++ b/docs/tech_guide/tecto.rst
@@ -51,10 +51,6 @@ The IIOE is formally second order accurate in space and time for 1D advection pr
 
 .. note::
 
-    **Cyclic (periodic) boundaries.** Horizontal advection works with a cyclic boundary (a periodic 2D model runs on a cylinder mesh). The displacement field is still given in the flat ``(vx, vy)`` frame; goSPL maps it onto the cylinder tangent so the periodic-axis component advects *around* the seam. The finite-volume advection then transports material across the periodic boundary through the wrapping cells (the seam is not pinned), so it remains mass-conserving across the seam.
-
-.. note::
-
     Velocity at the face is taken to be the linear interpolation for each vertex (in a vertex-centered discretisation the dual of the delaunay triangulation (i.e. the voronoi mesh has its edges on the middle of the nodes edges)).
 
     Similarly we consider that the advected variable at the face is defined by linear interpolation from each connected vertex.

--- a/docs/user_guide/inputfile.rst
+++ b/docs/user_guide/inputfile.rst
@@ -46,23 +46,8 @@ Initial mesh definition and simulation declaration
            - ``o`` — **open**: a deep base-level outlet (the edge is held below sea level); water and the sediment it carries drain out across it.
            - ``f`` — **fixed**: a base-level outlet at the natural edge elevation; flow and sediment still leave the domain there (this is *not* a no-flux wall).
            - ``w`` — **wall**: a true no-flux wall; flow is contained and sediment deposits against the edge instead of draining out.
-           - ``c`` — **cyclic** (periodic): flow and sediment wrap from one edge to the opposite one.
 
            Legacy digits are accepted: ``0`` is read as ``o`` (open) and ``1`` as ``f`` (fixed). The default is ``'oooo'``. For example ``'ofof'`` opens north/south with fixed east/west; ``'wfwf'`` walls north/south with fixed east/west.
-
-           Cyclic edges must be set as an **opposite pair** — both ``south`` and ``north``, *or* both ``east`` and ``west`` — and **at most one pair** may be cyclic (so up to two periodic edges, never all four). For example ``'ococ'`` makes east/west periodic with open north/south.
-
-           .. important::
-
-              A cyclic run **requires a periodic input mesh** in that direction: the mesh must be a **cylinder** (the periodic axis wrapped onto a circle whose circumference is the domain width), so that its cells genuinely connect the two seam edges. A cylinder is intrinsically flat, so its finite-volume geometry is identical to a periodic flat strip's; goSPL detects the cylinder's two open ends as the (non-periodic) boundary and routes flow/sediment across the seam through the wrapping cells. goSPL does **not** synthesise the wrap from an ordinary flat mesh (a planar wrap would have incorrect seam geometry).
-
-              .. warning::
-
-                 Cyclic boundaries are currently **serial-only** (a single MPI rank). When the periodic cylinder seam is split by the parallel partitioner the finite-volume operators become ill-conditioned, so a parallel cyclic run hangs (sediment-deposition diffusion) or collapses the elevation field (horizontal advection). goSPL therefore **raises an error** if a cyclic ``bc`` is combined with more than one MPI rank. Run cyclic models on a single rank, or use open/fixed/wall boundaries for parallel runs. (A parallel-safe cylinder-seam discretisation is planned.)
-
-           .. note::
-
-              **Horizontal advection on a cyclic mesh.** When ``tectonics`` horizontal displacements (``hdisp``) are applied together with a cyclic boundary, the displacement field is still supplied in the ordinary flat ``(vx, vy)`` frame (exactly as for a planar model). goSPL maps it onto the cylinder tangent automatically: the component along the periodic axis becomes motion *around* the cylinder (so material advects across the seam), while the non-periodic component stays along the cylinder axis. The advected fields wrap across the seam and the periodic edge is never pinned, so advection remains mass-conserving across the boundary.
 
            .. note::
 


### PR DESCRIPTION
Cyclic (periodic) boundaries work only in **serial** and still deadlock in parallel for flow+sediment (tracked in #477), so they are not ready for general use. This removes the user-facing documentation that would lead users to try them.

- `user_guide/inputfile.rst`: drop the `c` (cyclic) `bc` option, the opposite-pair rule, the cylinder-mesh requirement note, the serial-only warning, and the cyclic horizontal-advection note. The `bc` docs now describe only **open / fixed / wall**.
- `tech_guide/tecto.rst`: drop the cyclic-boundary advection note.

No code change — the parser still accepts `bc` `'c'` and raises a clear serial-only error at MPIsize>1 (from #475). This only removes the documentation so users aren't directed to the feature. The unrelated flexure BC option named `Periodic` in `optfile2.rst` is intentionally left.